### PR TITLE
feat: podcast episode detail

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Podcast episode metadata sheet with full details
+- Episode progress percentage displayed inline in episode list tiles
+- Play confirmation dialog when tapping an episode tile
+
+### Changed
+
+- Episode list tile simplified
+- Hide action buttons for podcasts
+
 ## [v0.4.0] - 2026-06-20
 
 ### Added

--- a/lib/features/item/ui/action_buttons.dart
+++ b/lib/features/item/ui/action_buttons.dart
@@ -21,6 +21,7 @@ class ActionButtons extends ConsumerWidget {
     return Row(
       mainAxisAlignment: .spaceEvenly,
       children: [
+        // TODO: support podcast episode downloads
         DownloadButton(libraryItemId: item.id),
         HistoryButton(itemId: item.id),
         if (progress != 1.0)
@@ -50,6 +51,7 @@ class ActionButtons extends ConsumerWidget {
             ),
             icon: const Icon(Icons.check_rounded),
           ),
+        // TODO: support removing podcast episode progress
         if (mediaProgress != null)
           IconButton(
             tooltip: l10n.removeProgressTitle,

--- a/lib/features/item/ui/episode_list.dart
+++ b/lib/features/item/ui/episode_list.dart
@@ -5,11 +5,15 @@ import 'package:storii/app/config/constants.dart';
 import 'package:storii/app/init.dart';
 import 'package:storii/app/providers/settings_provider.dart';
 import 'package:storii/features/item/logic/episode_filter_provider.dart';
+import 'package:storii/features/item/logic/progress_notifier.dart';
 import 'package:storii/features/item/ui/episode_list_header.dart';
+import 'package:storii/features/item/ui/episode_metadata_sheet.dart';
 import 'package:storii/features/player/logic/audio_providers.dart';
 import 'package:storii/features/player/logic/session_notifier.dart';
 import 'package:storii/shared/helpers/extensions.dart';
 import 'package:storii/shared/helpers/helpers.dart';
+import 'package:storii/shared/widgets/app_bottom_sheet.dart';
+import 'package:storii/shared/widgets/app_dialog.dart';
 import 'package:storii/shared/widgets/pulsing_dot.dart';
 
 class EpisodeList extends ConsumerWidget {
@@ -32,11 +36,7 @@ class EpisodeList extends ConsumerWidget {
         const Divider(height: 0),
         ...List.generate(
           filtered.length,
-          (index) => _EpisodeTile(
-            episode: filtered[index],
-            index: index,
-            itemId: itemId,
-          ),
+          (index) => _EpisodeTile(episode: filtered[index], itemId: itemId),
         ),
       ],
     );
@@ -44,14 +44,9 @@ class EpisodeList extends ConsumerWidget {
 }
 
 class _EpisodeTile extends ConsumerWidget {
-  const _EpisodeTile({
-    required this.episode,
-    required this.index,
-    required this.itemId,
-  });
+  const _EpisodeTile({required this.episode, required this.itemId});
 
   final PodcastEpisode episode;
-  final int index;
   final String itemId;
 
   @override
@@ -61,10 +56,10 @@ class _EpisodeTile extends ConsumerWidget {
         session != null && session.libraryItemId == itemId;
     final isCurrentEpisode =
         isCurrentItemPlaying && session.episodeId == episode.id;
-    final isPlaying = isCurrentEpisode && ref.watch(isPlayingProvider);
+    final progress = ref.watch(mediaProgressProvider(itemId, episode.id)).value;
 
-    final textTheme = Theme.of(context).textTheme;
     final scheme = Theme.of(context).colorScheme;
+    final textTheme = Theme.of(context).textTheme;
 
     final episodeNumber = episode.episode != null && episode.season != null
         ? 'S${episode.season} E${episode.episode}'
@@ -72,16 +67,37 @@ class _EpisodeTile extends ConsumerWidget {
         ? 'E${episode.episode}'
         : null;
 
+    final progressPct =
+        progress != null &&
+            progress.currentTime != null &&
+            episode.duration.inSeconds > 0
+        ? (progress.currentTime!.inSeconds / episode.duration.inSeconds * 100)
+              .round()
+        : null;
+
     return InkWell(
       borderRadius: .circular(kRadius),
       onTap: () {
-        if (!isCurrentEpisode) {
-          ref
-              .read(audioPlayerProvider.notifier)
-              .play(itemId: itemId, episodeId: episode.id);
-        }
+        if (isCurrentEpisode) return;
+        AppDialog.show(
+          context,
+          title: episode.title ?? l10n.noTitle,
+          body: Text(l10n.playEpisodeConfirm),
+          actionLabel: l10n.play,
+          onTap: () async {
+            await ref
+                .read(audioPlayerProvider.notifier)
+                .play(itemId: itemId, episodeId: episode.id);
+          },
+        );
       },
-      child: Padding(
+      child: Container(
+        decoration: BoxDecoration(
+          color: isCurrentEpisode
+              ? scheme.primary.withValues(alpha: 0.08)
+              : null,
+          borderRadius: .circular(kRadius),
+        ),
         padding: const .symmetric(horizontal: 16, vertical: 12),
         child: Row(
           crossAxisAlignment: .center,
@@ -116,62 +132,62 @@ class _EpisodeTile extends ConsumerWidget {
                       color: isCurrentEpisode ? scheme.primary : null,
                     ),
                   ),
-                  if (episode.subtitle != null) ...[
-                    const SizedBox(height: 2),
-                    Text(
-                      episode.subtitle!,
-                      maxLines: 1,
-                      overflow: .ellipsis,
-                      style: textTheme.bodySmall?.copyWith(
-                        color: scheme.onSurfaceVariant.withValues(alpha: 0.7),
-                      ),
-                    ),
-                  ],
                   const SizedBox(height: 4),
-                  Wrap(
-                    spacing: 12,
-                    runSpacing: 4,
-                    children: [
-                      Text(
-                        episode.duration.toReadableDuration(),
-                        style: textTheme.labelSmall?.copyWith(
-                          color: scheme.onSurfaceVariant,
-                        ),
-                      ),
-                      Text(
-                        episode.publishedAt.fString(
-                          format: ref.watch(dateTimeFormatProvider),
-                        ),
-                        style: textTheme.labelSmall?.copyWith(
-                          color: scheme.onSurfaceVariant,
-                        ),
-                      ),
-                      if (episode.size != null)
-                        Text(
-                          formatBytes(
-                            episode.size!,
-                            useBinary: ref.watch(useBinaryBytesProvider),
-                          ),
-                          style: textTheme.labelSmall?.copyWith(
-                            color: scheme.onSurfaceVariant,
-                          ),
-                        ),
-                    ],
-                  ),
-                  // TODO: add description, progress, more metadata icon sheet
+                  _EpisodeMetaRow(episode: episode, progressPct: progressPct),
                 ],
               ),
             ),
-            Icon(
-              isPlaying ? Icons.pause_circle : Icons.play_circle_outline,
-              color: isCurrentEpisode
-                  ? scheme.primary
-                  : scheme.onSurfaceVariant,
-              size: 24,
+            const SizedBox(width: 8),
+            IconButton(
+              icon: Icon(
+                Icons.info_outline,
+                size: 20,
+                color: scheme.onSurfaceVariant.withValues(alpha: 0.6),
+              ),
+              padding: .zero,
+              constraints: const BoxConstraints(minWidth: 28, minHeight: 28),
+              onPressed: () {
+                AppBottomSheet.show(
+                  context,
+                  title: l10n.metadata,
+                  body: EpisodeMetadataSheet(episode: episode),
+                );
+              },
             ),
           ],
         ),
       ),
+    );
+  }
+}
+
+class _EpisodeMetaRow extends ConsumerWidget {
+  const _EpisodeMetaRow({required this.episode, this.progressPct});
+
+  final PodcastEpisode episode;
+  final int? progressPct;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final style = Theme.of(context).textTheme.labelSmall?.copyWith(
+      color: Theme.of(context).colorScheme.onSurfaceVariant,
+    );
+    final parts = <String>[
+      if (progressPct != null) '$progressPct%',
+      episode.duration.toReadableDuration(),
+      episode.publishedAt.fString(format: ref.watch(dateTimeFormatProvider)),
+      if (episode.size != null)
+        formatBytes(
+          episode.size!,
+          useBinary: ref.watch(useBinaryBytesProvider),
+        ),
+    ];
+
+    return Text(
+      parts.join(' • '),
+      style: style,
+      maxLines: 1,
+      overflow: .ellipsis,
     );
   }
 }

--- a/lib/features/item/ui/episode_list.dart
+++ b/lib/features/item/ui/episode_list.dart
@@ -138,6 +138,8 @@ class _EpisodeTile extends ConsumerWidget {
               ),
             ),
             const SizedBox(width: 8),
+            // TODO: add download button for podcast episodes
+            // TODO: add mark complete / remove progress for podcast episodes
             IconButton(
               icon: Icon(
                 Icons.info_outline,

--- a/lib/features/item/ui/episode_list_header.dart
+++ b/lib/features/item/ui/episode_list_header.dart
@@ -24,7 +24,9 @@ class EpisodeListHeader extends ConsumerWidget {
       child: Row(
         children: [
           Text(
-            filter == .all ? l10n.episodes : '$episodeCount / $totalCount',
+            filter == .all
+                ? '${l10n.episodes} ($episodeCount)'
+                : '$episodeCount / $totalCount',
             style: Theme.of(
               context,
             ).textTheme.titleMedium?.copyWith(fontWeight: .w600),

--- a/lib/features/item/ui/episode_metadata_sheet.dart
+++ b/lib/features/item/ui/episode_metadata_sheet.dart
@@ -1,0 +1,113 @@
+import 'package:abs_api/abs_api.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:storii/app/init.dart';
+import 'package:storii/app/providers/settings_provider.dart';
+import 'package:storii/shared/helpers/extensions.dart';
+import 'package:storii/shared/helpers/helpers.dart';
+
+class EpisodeMetadataSheet extends ConsumerWidget {
+  const EpisodeMetadataSheet({super.key, required this.episode});
+  final PodcastEpisode episode;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final theme = Theme.of(context);
+    final rows = <_RowData>[
+      _RowData(l10n.id, episode.id),
+      _RowData(l10n.title, episode.title),
+      _RowData(l10n.season, episode.season),
+      _RowData(l10n.episode, episode.episode),
+      _RowData(l10n.type, episode.episodeType),
+      _RowData(l10n.subtitle, episode.subtitle),
+      _RowData(l10n.duration, episode.duration.toReadableDuration()),
+      _RowData(
+        l10n.publishedDate,
+        episode.publishedAt.fString(format: ref.watch(dateTimeFormatProvider)),
+      ),
+      _RowData(l10n.pubDate, episode.pubDate),
+      _RowData(
+        l10n.added,
+        episode.addedAt.fString(format: ref.watch(dateTimeFormatProvider)),
+      ),
+      _RowData(
+        l10n.size,
+        episode.size != null
+            ? formatBytes(
+                episode.size!,
+                useBinary: ref.watch(useBinaryBytesProvider),
+              )
+            : null,
+      ),
+      _RowData(l10n.codec, episode.audioFile.codec),
+      _RowData(
+        l10n.bitrate,
+        episode.audioFile.bitRate != null
+            ? '${episode.audioFile.bitRate} kbps'
+            : null,
+      ),
+      _RowData(l10n.channels, episode.audioFile.channels?.toString()),
+      _RowData(l10n.mimeType, episode.audioFile.mimeType),
+      _RowData(l10n.format, episode.audioFile.format),
+    ];
+
+    final description = episode.description?.trim();
+    final hasDescription = description != null && description.isNotEmpty;
+
+    return SingleChildScrollView(
+      padding: const .fromLTRB(24, 0, 24, 24),
+      child: SelectableRegion(
+        selectionControls: MaterialTextSelectionControls(),
+        child: Column(
+          crossAxisAlignment: .start,
+          children: [
+            ...rows
+                .where((r) => r.value != null && r.value!.isNotEmpty)
+                .map(
+                  (r) => Padding(
+                    padding: const .symmetric(vertical: 4),
+                    child: Row(
+                      crossAxisAlignment: .start,
+                      children: [
+                        SizedBox(
+                          width: 80,
+                          child: Text(
+                            r.label,
+                            style: theme.textTheme.labelSmall?.copyWith(
+                              color: theme.colorScheme.onSurfaceVariant,
+                            ),
+                          ),
+                        ),
+                        Expanded(
+                          child: Text(
+                            r.value!,
+                            style: theme.textTheme.bodyMedium,
+                          ),
+                        ),
+                      ],
+                    ),
+                  ),
+                ),
+            if (hasDescription) ...[
+              const SizedBox(height: 16),
+              Text(
+                l10n.description,
+                style: theme.textTheme.labelSmall?.copyWith(
+                  color: theme.colorScheme.onSurfaceVariant,
+                ),
+              ),
+              const SizedBox(height: 8),
+              Text(description, style: theme.textTheme.bodyMedium),
+            ],
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _RowData {
+  const _RowData(this.label, this.value);
+  final String label;
+  final String? value;
+}

--- a/lib/features/item/ui/item_detail_screen.dart
+++ b/lib/features/item/ui/item_detail_screen.dart
@@ -58,7 +58,7 @@ class ItemDetailScreen extends ConsumerWidget {
                           const SizedBox(height: 8),
                           PlayButton(item),
                           ProgressBar(itemId: item.id),
-                          ActionButtons(item: item),
+                          if (item.isBook) ActionButtons(item: item),
                         ],
                       ),
                     ),

--- a/lib/features/player/logic/session_extensions.dart
+++ b/lib/features/player/logic/session_extensions.dart
@@ -69,18 +69,32 @@ extension PlaybackSessionX on PlaybackSession {
           : serverUrl!.resolve(track.contentUrl);
       //! either we get local path or server url
 
+      final isEpisode = mediaType == .podcast && episodeId != null;
+      final episodeTitle = isEpisode
+          ? libraryItem?.episodes
+                .firstWhereOrNull((e) => e.id == episodeId)
+                ?.title
+          : null;
+      final episodeSubtitle = isEpisode
+          ? libraryItem?.episodes
+                .firstWhereOrNull((e) => e.id == episodeId)
+                ?.subtitle
+          : null;
+
       final tag = MediaItem(
         id: track.contentUrl,
-        title: displayTitle ?? l10n.noTitle,
-        artist: displayAuthor,
+        title: episodeTitle ?? displayTitle ?? l10n.noTitle,
+        artist: episodeSubtitle ?? displayAuthor,
         duration: track.duration,
-        album: mediaMetadata.mapOrNull(book: (b) => b.seriesName),
+        album: isEpisode
+            ? displayTitle
+            : mediaMetadata.mapOrNull(book: (b) => b.seriesName),
         artUri: coverUri,
         extras: {
           if (index == 0) 'chapters': jsonChapters,
           'startOffset': startOffset.inMicroseconds,
           'itemId': libraryItemId,
-          if (mediaType == .podcast) 'episodeId': episodeId,
+          if (isEpisode) 'episodeId': episodeId,
           'isLocal': isLocal,
         },
       );

--- a/lib/features/player/ui/book_slider.dart
+++ b/lib/features/player/ui/book_slider.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:storii/features/player/logic/audio_providers.dart';
+import 'package:storii/features/player/logic/session_extensions.dart';
+import 'package:storii/features/player/logic/session_notifier.dart';
 import 'package:storii/shared/helpers/extensions.dart';
 
 class BookSlider extends ConsumerStatefulWidget {
@@ -16,10 +18,27 @@ class _BookSliderState extends ConsumerState<BookSlider> {
 
   @override
   Widget build(BuildContext context) {
+    final session = ref.watch(sessionProvider);
+    final isEpisode = session?.isPodcastEpisode ?? false;
+
     final chapter = ref.watch(currentChapterProvider).value;
-    final position = ref.watch(chapterPositionProvider).value;
-    final durationMs = (chapter?.duration.inMilliseconds ?? 0).toDouble();
-    double positionMs = (position?.inMilliseconds.toDouble() ?? 0.0).clamp(
+    final chapterPosition = ref.watch(chapterPositionProvider).value;
+    final globalPosition = ref.watch(globalPositionProvider).value;
+    final totalDuration = ref.watch(totalDurationProvider);
+
+    final Duration duration;
+    final Duration position;
+
+    if (isEpisode) {
+      duration = totalDuration;
+      position = globalPosition ?? Duration.zero;
+    } else {
+      duration = chapter?.duration ?? Duration.zero;
+      position = chapterPosition ?? Duration.zero;
+    }
+
+    final durationMs = duration.inMilliseconds.toDouble();
+    double positionMs = position.inMilliseconds.toDouble().clamp(
       0.0,
       durationMs,
     );
@@ -50,7 +69,13 @@ class _BookSliderState extends ConsumerState<BookSlider> {
                 _latestSeekValue = value;
                 _dragValue = null;
               });
-              await audioHandler.seek(Duration(milliseconds: value.toInt()));
+              if (isEpisode) {
+                await audioHandler.seekFromGlobalPosition(
+                  Duration(milliseconds: value.toInt()),
+                );
+              } else {
+                await audioHandler.seek(Duration(milliseconds: value.toInt()));
+              }
             },
           ),
         ),
@@ -60,7 +85,7 @@ class _BookSliderState extends ConsumerState<BookSlider> {
             mainAxisAlignment: .spaceBetween,
             children: [
               Text(format(_dragValue ?? positionMs)),
-              Text(chapter?.duration.toTime() ?? ''),
+              Text(duration.toTime()),
             ],
           ),
         ),

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -62,6 +62,7 @@
   "audiobooks": "Audiobooks",
   "podcasts": "Podcasts",
   "episodes": "Episodes",
+  "playEpisodeConfirm": "Play this episode?",
   "search": "Search",
   "dateFormat": "Date Format",
   "custom": "Custom",
@@ -362,5 +363,11 @@
   "binaryUnitsSubtitle": "1 KB = 1024 B",
   "decimalUnits": "Decimal units",
   "decimalUnitsSubtitle": "1 KB = 1000 B",
-  "marqueeSpeed": "Text Scroll Speed"
+  "marqueeSpeed": "Text Scroll Speed",
+  "type": "Type",
+  "pubDate": "Pub Date",
+  "added": "Added",
+  "mimeType": "MIME Type",
+  "season": "Season",
+  "episode": "Episode"
 }

--- a/lib/l10n/l10n.dart
+++ b/lib/l10n/l10n.dart
@@ -382,6 +382,12 @@ abstract class AppLocalizations {
   /// **'Episodes'**
   String get episodes;
 
+  /// No description provided for @playEpisodeConfirm.
+  ///
+  /// In en, this message translates to:
+  /// **'Play this episode?'**
+  String get playEpisodeConfirm;
+
   /// No description provided for @search.
   ///
   /// In en, this message translates to:
@@ -1695,6 +1701,42 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Text Scroll Speed'**
   String get marqueeSpeed;
+
+  /// No description provided for @type.
+  ///
+  /// In en, this message translates to:
+  /// **'Type'**
+  String get type;
+
+  /// No description provided for @pubDate.
+  ///
+  /// In en, this message translates to:
+  /// **'Pub Date'**
+  String get pubDate;
+
+  /// No description provided for @added.
+  ///
+  /// In en, this message translates to:
+  /// **'Added'**
+  String get added;
+
+  /// No description provided for @mimeType.
+  ///
+  /// In en, this message translates to:
+  /// **'MIME Type'**
+  String get mimeType;
+
+  /// No description provided for @season.
+  ///
+  /// In en, this message translates to:
+  /// **'Season'**
+  String get season;
+
+  /// No description provided for @episode.
+  ///
+  /// In en, this message translates to:
+  /// **'Episode'**
+  String get episode;
 }
 
 class _AppLocalizationsDelegate

--- a/lib/l10n/l10n_en.dart
+++ b/lib/l10n/l10n_en.dart
@@ -157,6 +157,9 @@ class AppLocalizationsEn extends AppLocalizations {
   String get episodes => 'Episodes';
 
   @override
+  String get playEpisodeConfirm => 'Play this episode?';
+
+  @override
   String get search => 'Search';
 
   @override
@@ -858,4 +861,22 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get marqueeSpeed => 'Text Scroll Speed';
+
+  @override
+  String get type => 'Type';
+
+  @override
+  String get pubDate => 'Pub Date';
+
+  @override
+  String get added => 'Added';
+
+  @override
+  String get mimeType => 'MIME Type';
+
+  @override
+  String get season => 'Season';
+
+  @override
+  String get episode => 'Episode';
 }


### PR DESCRIPTION
## What does this PR do?

Podcast episode detail UI.

- Episode-aware now playing metadata
- Simplified episode list tiles with progress percentage, play confirm dialog, and info button
- New episode metadata bottom sheet with full details
- Hide download/action buttons for podcasts

## Type of Change

- [x] New feature
- [x] Docs / chore

## Checklist

- [x] `dart format .` and `dart fix --apply` have been run
- [x] No lint errors or warnings (infos for TODOs are okay)
- [x] Code generation has been run if models or providers were changed (`dart run build_runner build`)
- [x] No `print` statements introduced
- [x] Tested against an Audiobookshelf server