### PR TITLE
refactor: move StandaloneBooks to GoRouter as nested author detail route

### DIFF
--- a/lib/app/config/router.dart
+++ b/lib/app/config/router.dart
@@ -8,6 +8,7 @@ import 'package:storii/features/auth/logic/add_user_notifier.dart';
 import 'package:storii/features/auth/ui/server_list_screen.dart';
 import 'package:storii/features/author/ui/author_detail_screen.dart';
 import 'package:storii/features/author/ui/author_list_screen.dart';
+import 'package:storii/features/author/ui/standalone_books.dart';
 import 'package:storii/features/collections/ui/collections_screen.dart';
 import 'package:storii/features/downloads/ui/downloads_screen.dart';
 import 'package:storii/features/home/ui/home_screen.dart';
@@ -43,6 +44,7 @@ enum AppRoute {
   seriesDetail('/series/detail'),
   authors('/authors'),
   authorDetail('/authors/detail'),
+  authorBooks('/authors/detail/books'),
   collections('/collections'),
   downloads('/downloads'),
   more('/more'),
@@ -165,6 +167,15 @@ final routerProvider = Provider<GoRouter>((ref) {
                   final id = state.extra as String;
                   return AuthorDetailScreen(key: ValueKey(id), id: id);
                 },
+                routes: [
+                  GoRoute(
+                    path: 'books',
+                    builder: (context, state) {
+                      final id = state.extra as String;
+                      return StandaloneBooks(key: ValueKey(id), id: id);
+                    },
+                  ),
+                ],
               ),
             ],
           ),

--- a/lib/features/author/ui/author_content.dart
+++ b/lib/features/author/ui/author_content.dart
@@ -5,7 +5,6 @@ import 'package:go_router/go_router.dart';
 import 'package:storii/app/config/constants.dart';
 import 'package:storii/app/config/router.dart';
 import 'package:storii/app/init.dart';
-import 'package:storii/features/author/ui/standalone_books.dart';
 import 'package:storii/features/library/logic/grid_height_provider.dart';
 import 'package:storii/features/library/ui/library_item_card.dart';
 
@@ -32,9 +31,7 @@ class AuthorContent extends StatelessWidget {
             title: l10n.books,
             count: books.length,
             onViewAll: () {
-              Navigator.of(context).push(
-                MaterialPageRoute(builder: (context) => StandaloneBooks(books)),
-              );
+              context.push(AppRoute.authorBooks.path, extra: authorId);
             },
           ),
           HorizontalBooksCarousel(books: books),

--- a/lib/features/author/ui/standalone_books.dart
+++ b/lib/features/author/ui/standalone_books.dart
@@ -1,25 +1,37 @@
-import 'package:abs_api/abs_api.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
 import 'package:storii/app/init.dart';
+import 'package:storii/features/author/logic/author_provider.dart';
 import 'package:storii/features/library/ui/items_grid_view.dart';
+import 'package:storii/shared/widgets/error_retry.dart';
+import 'package:storii/shared/widgets/waveform.dart';
 
 class StandaloneBooks extends ConsumerWidget {
-  const StandaloneBooks(this.books, {super.key});
+  const StandaloneBooks({super.key, required this.id});
 
-  final List<LibraryItem> books;
+  final String id;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
+    final authorAsync = ref.watch(authorProvider(id));
+
     return Scaffold(
       appBar: AppBar(
         leading: IconButton(
-          onPressed: () => Navigator.of(context).pop(),
+          onPressed: () => context.pop(),
           icon: const Icon(Icons.arrow_back),
         ),
         title: Text(l10n.books, style: Theme.of(context).textTheme.titleMedium),
       ),
-      body: ItemsGridView(books),
+      body: authorAsync.when(
+        data: (author) => ItemsGridView(author.libraryItems ?? []),
+        loading: () => const Center(child: RandomWaveform()),
+        error: (e, _) => ErrorRetryWidget(
+          e.toString(),
+          onRetry: () => ref.invalidate(authorProvider(id)),
+        ),
+      ),
     );
   }
 }


### PR DESCRIPTION
## What does this PR do?

Moves `StandaloneBooks` from a `Navigator.push` into the GoRouter route

## Type of Change

- [x] Refactor

## Checklist

- [x] `dart format .` and `dart fix --apply` have been run
- [x] No lint errors or warnings (infos for TODOs are okay)
- [x] Code generation has been run if models or providers were changed (`dart run build_runner build`)
- [x] No `print` statements introduced
- [x] Tested against an Audiobookshelf server
