### PR TITLE
fix: resolve bottom padding and image sizing issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Content padding to prevent overlap with Android navigation buttons
+- Bottom padding in about screen
+- Image sizing on smaller screens
+
 ## [v0.4.2] - 2026-06-22
 
 ### Added

--- a/lib/features/item/ui/cover_image_title.dart
+++ b/lib/features/item/ui/cover_image_title.dart
@@ -26,7 +26,7 @@ class CoverImageTitle extends StatelessWidget {
       children: [
         Material(
           child: AspectRatio(
-            aspectRatio: orientation == .landscape ? 1.6 : 1,
+            aspectRatio: orientation == .landscape ? 2 : 1,
             child: ImageFiltered(
               imageFilter: ImageFilter.blur(sigmaX: 30, sigmaY: 30),
               child: ImageWidget(

--- a/lib/features/more/ui/about_screen.dart
+++ b/lib/features/more/ui/about_screen.dart
@@ -99,10 +99,15 @@ class AboutScreen extends ConsumerWidget {
                     mainAxisSize: .min,
                     children: [
                       const Text('Built with '),
-                      Icon(Icons.favorite, size: 16, color: scheme.error),
+                      Icon(
+                        Icons.favorite,
+                        size: 16,
+                        color: scheme.errorContainer,
+                      ),
                       const Text(' in Flutter'),
                     ],
                   ),
+                  SizedBox(height: MediaQuery.paddingOf(context).bottom),
                 ],
               ),
             ),

--- a/lib/features/player/ui/player_screen.dart
+++ b/lib/features/player/ui/player_screen.dart
@@ -1,4 +1,5 @@
 import 'dart:developer';
+import 'dart:math' as math;
 
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -36,7 +37,10 @@ class PlayerScreen extends ConsumerWidget {
 
     final maxImgSize = isLandscape
         ? (screenHeight - 64).clamp(0.0, maxImgSizeInFullPlayer)
-        : (screenWidth - 32).clamp(0.0, maxImgSizeInFullPlayer);
+        : (screenWidth - 32).clamp(
+            0.0,
+            math.min(maxImgSizeInFullPlayer, screenHeight * 0.4),
+          );
     final targetImgLeft = isLandscape
         ? (screenWidth * 0.25) - (maxImgSize / 2)
         : (screenWidth - maxImgSize) / 2;

--- a/lib/shared/widgets/nav_bar.dart
+++ b/lib/shared/widgets/nav_bar.dart
@@ -15,23 +15,27 @@ class NavBar extends ConsumerWidget {
     final scheme = Theme.of(context).colorScheme;
     final labelBehavior = ref.watch(navLabelBehaviorProvider);
 
-    return NavigationBar(
-      selectedIndex: currentIndex,
-      backgroundColor: scheme.surfaceContainer,
-      elevation: 2,
-      labelBehavior: labelBehavior,
-      onDestinationSelected: (index) {
-        if (index == currentIndex) return;
-        onTap(index);
-      },
-      destinations: [
-        for (final target in targets)
-          NavigationDestination(
-            icon: Icon(target.item.icon),
-            label: target.label,
-            selectedIcon: Icon(target.item.selectedIcon),
-          ),
-      ],
+    return MediaQuery.removePadding(
+      context: context,
+      removeBottom: true,
+      child: NavigationBar(
+        selectedIndex: currentIndex,
+        backgroundColor: scheme.surfaceContainer,
+        elevation: 2,
+        labelBehavior: labelBehavior,
+        onDestinationSelected: (index) {
+          if (index == currentIndex) return;
+          onTap(index);
+        },
+        destinations: [
+          for (final target in targets)
+            NavigationDestination(
+              icon: Icon(target.item.icon),
+              label: target.label,
+              selectedIcon: Icon(target.item.selectedIcon),
+            ),
+        ],
+      ),
     );
   }
 }

--- a/lib/shared/widgets/shell_scaffold.dart
+++ b/lib/shared/widgets/shell_scaffold.dart
@@ -26,6 +26,8 @@ class ShellScaffold extends ConsumerWidget {
       (t) => t.item.route.path == path,
     );
 
+    final factor = ref.watch(playerExpandFactorProvider);
+
     return PopScope(
       canPop: path == AppRoute.home.path,
       onPopInvokedWithResult: (didPop, _) async {
@@ -40,12 +42,21 @@ class ShellScaffold extends ConsumerWidget {
       },
       child: Scaffold(
         key: shellScaffoldKey,
-        bottomNavigationBar: Column(
-          mainAxisSize: .min,
-          children: [
-            const PlayerScreen(),
-            _ShellBottomBar(target: target, navTargets: navTargets),
-          ],
+        bottomNavigationBar: Padding(
+          padding: .only(
+            bottom: MediaQuery.paddingOf(context).bottom * (1.0 - factor),
+          ),
+          child: Column(
+            mainAxisSize: .min,
+            children: [
+              const PlayerScreen(),
+              _ShellBottomBar(
+                target: target,
+                navTargets: navTargets,
+                factor: factor,
+              ),
+            ],
+          ),
         ),
         body: child,
       ),
@@ -59,14 +70,19 @@ final lastNavIndexProvider = StateProvider<int>(
 );
 
 class _ShellBottomBar extends ConsumerWidget {
-  const _ShellBottomBar({required this.target, required this.navTargets});
+  const _ShellBottomBar({
+    required this.target,
+    required this.navTargets,
+    required this.factor,
+  });
 
   final NavTarget? target;
   final List<NavTarget> navTargets;
+  final double factor;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final factor = ref.watch(playerExpandFactorProvider);
+    if (factor >= 0.4) return const SizedBox.shrink();
 
     if (target != null) {
       final index = navTargets.indexOf(target!);
@@ -75,8 +91,6 @@ class _ShellBottomBar extends ConsumerWidget {
       );
     }
     final displayIndex = ref.watch(lastNavIndexProvider);
-
-    if (factor >= 0.4) return const SizedBox.shrink();
 
     final isTargetNull = target == null;
     final factorVisibility = (1.0 - (factor / 0.3)).clamp(0.0, 1.0);


### PR DESCRIPTION
## What does this PR do?

Fixes -

- Content padding to prevent overlap with Android navigation buttons
- Bottom padding in about screen
- Image sizing on smaller screens

Closes #41

## Type of Change

- [x] Bug fix

## Checklist

- [x] `dart format .` and `dart fix --apply` have been run
- [x] No lint errors or warnings (infos for TODOs are okay)
- [x] Code generation has been run if models or providers were changed (`dart run build_runner build`)
- [x] No `print` statements introduced
- [x] Tested against an Audiobookshelf server
