### PR TITLE
fix: sync playback position to OS media controls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Sync playback position and index to OS media controls during playback
+
 ## [v0.4.3] - 2026-06-24
 
 ### Fixed

--- a/lib/features/player/logic/audio_handler.dart
+++ b/lib/features/player/logic/audio_handler.dart
@@ -113,12 +113,10 @@ class AppAudioHandler extends BaseAudioHandler with QueueHandler, SeekHandler {
 
     mediaItem.add(queue.value.elementAtOrNull(resolved.chapterIndex));
 
-    final resolvedBuffered = resolver.resolveChapterFromTrack(
-      state.index,
-      state.bufferedPosition,
-    );
+    final resolvedBuffered =
+        resolver.resolveChapterFromTrack(state.index, state.bufferedPosition) ??
+        resolved;
 
-    final oldPlaybackState = playbackState.value;
     playbackState.add(
       playbackState.value.copyWith(
         processingState: switch (state.status) {
@@ -131,9 +129,7 @@ class AppAudioHandler extends BaseAudioHandler with QueueHandler, SeekHandler {
         },
         playing: state.isPlaying,
         updatePosition: resolved.chapterPosition,
-        bufferedPosition:
-            resolvedBuffered?.chapterPosition ??
-            oldPlaybackState.bufferedPosition,
+        bufferedPosition: resolvedBuffered.chapterPosition,
         speed: state.speed,
         queueIndex: resolved.chapterIndex,
         errorMessage: state.error?.name,

--- a/lib/features/player/logic/just_audio_player.dart
+++ b/lib/features/player/logic/just_audio_player.dart
@@ -71,18 +71,14 @@ class JustAudioPlayer implements AppAudioPlayer {
 
   @override
   Stream<AppPlaybackState> get stateStream => Rx.merge([
-    _player.playbackEventStream.map(
-      (event) => AppPlaybackState(
-        status: _mapState(event.processingState),
-        index: event.currentIndex,
-        position: event.updatePosition,
-        bufferedPosition: event.bufferedPosition,
-        error: null,
-        isPlaying: _player.playing,
-        speed: _player.speed,
-        volume: _player.volume,
-      ),
-    ),
+    _player.playbackEventStream.map((_) => state.copyWith(error: null)),
+    _player.positionStream
+        .throttleTime(
+          const Duration(seconds: 3),
+          leading: false,
+          trailing: true,
+        )
+        .map((_) => state.copyWith(error: null)),
     _errorController.stream.map((msg) => state.copyWith(error: msg)),
   ]);
 


### PR DESCRIPTION
## What does this PR do?

sync correct playback position and index to playbackState

## Type of Change

- [x] Bug fix

## Checklist

- [x] `dart format .` and `dart fix --apply` have been run
- [x] No lint errors or warnings (infos for TODOs are okay)
- [x] Code generation has been run if models or providers were changed (`dart run build_runner build`)
- [x] No `print` statements introduced
- [x] Tested against an Audiobookshelf server