### PR TITLE
Fix podcast metadata type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Crash parsing podcast metadata
+
 ## [v0.4.4] - 2026-06-25
 
 ### Fixed

--- a/lib/features/item/ui/more_metadata.dart
+++ b/lib/features/item/ui/more_metadata.dart
@@ -88,11 +88,8 @@ class _MoreMetadataSheet extends StatelessWidget {
           l10n.itunesPageUrl,
           podcastMetadata.itunesPageUrl.toString(),
         ),
-        _MetadataRow(l10n.itunesId, podcastMetadata.itunesId.toString()),
-        _MetadataRow(
-          l10n.itunesArtistId,
-          podcastMetadata.itunesArtistId.toString(),
-        ),
+        _MetadataRow(l10n.itunesId, podcastMetadata.itunesId),
+        _MetadataRow(l10n.itunesArtistId, podcastMetadata.itunesArtistId),
         _MetadataRow(l10n.language, podcastMetadata.language),
         _MetadataRow(l10n.explicit, podcastMetadata.explicit.toString()),
       ]);

--- a/packages/abs_api/lib/src/models/media_metadata.dart
+++ b/packages/abs_api/lib/src/models/media_metadata.dart
@@ -44,8 +44,8 @@ sealed class MediaMetadata with _$MediaMetadata {
     Uri? feedUrl,
     Uri? imageUrl,
     Uri? itunesPageUrl,
-    int? itunesId,
-    int? itunesArtistId,
+    String? itunesId,
+    String? itunesArtistId,
     @Default(false) bool explicit,
     String? language,
   }) = PodcastMetadata;

--- a/packages/abs_api/lib/src/models/media_metadata.freezed.dart
+++ b/packages/abs_api/lib/src/models/media_metadata.freezed.dart
@@ -181,7 +181,7 @@ return podcast(_that);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult maybeWhen<TResult extends Object?>({TResult Function( String? title,  String? titleIgnorePrefix,  String? subtitle,  List<Author>? authors,  List<String>? narrators, @JsonKey(readValue: _readSeries)  List<Series>? series,  List<String> genres,  String? publishedYear,  String? publishedDate,  String? publisher,  String? description,  String? isbn,  String? asin,  String? language,  bool explicit,  bool? abridged,  String? authorName,  String? authorNameLF,  String? narratorName,  String? seriesName,  String? descriptionPlain)?  book,TResult Function( String? title,  String? titleIgnorePrefix,  String? author,  String? description,  DateTime? releaseDate,  List<String> genres,  Uri? feedUrl,  Uri? imageUrl,  Uri? itunesPageUrl,  int? itunesId,  int? itunesArtistId,  bool explicit,  String? language)?  podcast,required TResult orElse(),}) {final _that = this;
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>({TResult Function( String? title,  String? titleIgnorePrefix,  String? subtitle,  List<Author>? authors,  List<String>? narrators, @JsonKey(readValue: _readSeries)  List<Series>? series,  List<String> genres,  String? publishedYear,  String? publishedDate,  String? publisher,  String? description,  String? isbn,  String? asin,  String? language,  bool explicit,  bool? abridged,  String? authorName,  String? authorNameLF,  String? narratorName,  String? seriesName,  String? descriptionPlain)?  book,TResult Function( String? title,  String? titleIgnorePrefix,  String? author,  String? description,  DateTime? releaseDate,  List<String> genres,  Uri? feedUrl,  Uri? imageUrl,  Uri? itunesPageUrl,  String? itunesId,  String? itunesArtistId,  bool explicit,  String? language)?  podcast,required TResult orElse(),}) {final _that = this;
 switch (_that) {
 case BookMetadata() when book != null:
 return book(_that.title,_that.titleIgnorePrefix,_that.subtitle,_that.authors,_that.narrators,_that.series,_that.genres,_that.publishedYear,_that.publishedDate,_that.publisher,_that.description,_that.isbn,_that.asin,_that.language,_that.explicit,_that.abridged,_that.authorName,_that.authorNameLF,_that.narratorName,_that.seriesName,_that.descriptionPlain);case PodcastMetadata() when podcast != null:
@@ -203,7 +203,7 @@ return podcast(_that.title,_that.titleIgnorePrefix,_that.author,_that.descriptio
 /// }
 /// ```
 
-@optionalTypeArgs TResult when<TResult extends Object?>({required TResult Function( String? title,  String? titleIgnorePrefix,  String? subtitle,  List<Author>? authors,  List<String>? narrators, @JsonKey(readValue: _readSeries)  List<Series>? series,  List<String> genres,  String? publishedYear,  String? publishedDate,  String? publisher,  String? description,  String? isbn,  String? asin,  String? language,  bool explicit,  bool? abridged,  String? authorName,  String? authorNameLF,  String? narratorName,  String? seriesName,  String? descriptionPlain)  book,required TResult Function( String? title,  String? titleIgnorePrefix,  String? author,  String? description,  DateTime? releaseDate,  List<String> genres,  Uri? feedUrl,  Uri? imageUrl,  Uri? itunesPageUrl,  int? itunesId,  int? itunesArtistId,  bool explicit,  String? language)  podcast,}) {final _that = this;
+@optionalTypeArgs TResult when<TResult extends Object?>({required TResult Function( String? title,  String? titleIgnorePrefix,  String? subtitle,  List<Author>? authors,  List<String>? narrators, @JsonKey(readValue: _readSeries)  List<Series>? series,  List<String> genres,  String? publishedYear,  String? publishedDate,  String? publisher,  String? description,  String? isbn,  String? asin,  String? language,  bool explicit,  bool? abridged,  String? authorName,  String? authorNameLF,  String? narratorName,  String? seriesName,  String? descriptionPlain)  book,required TResult Function( String? title,  String? titleIgnorePrefix,  String? author,  String? description,  DateTime? releaseDate,  List<String> genres,  Uri? feedUrl,  Uri? imageUrl,  Uri? itunesPageUrl,  String? itunesId,  String? itunesArtistId,  bool explicit,  String? language)  podcast,}) {final _that = this;
 switch (_that) {
 case BookMetadata():
 return book(_that.title,_that.titleIgnorePrefix,_that.subtitle,_that.authors,_that.narrators,_that.series,_that.genres,_that.publishedYear,_that.publishedDate,_that.publisher,_that.description,_that.isbn,_that.asin,_that.language,_that.explicit,_that.abridged,_that.authorName,_that.authorNameLF,_that.narratorName,_that.seriesName,_that.descriptionPlain);case PodcastMetadata():
@@ -221,7 +221,7 @@ return podcast(_that.title,_that.titleIgnorePrefix,_that.author,_that.descriptio
 /// }
 /// ```
 
-@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>({TResult? Function( String? title,  String? titleIgnorePrefix,  String? subtitle,  List<Author>? authors,  List<String>? narrators, @JsonKey(readValue: _readSeries)  List<Series>? series,  List<String> genres,  String? publishedYear,  String? publishedDate,  String? publisher,  String? description,  String? isbn,  String? asin,  String? language,  bool explicit,  bool? abridged,  String? authorName,  String? authorNameLF,  String? narratorName,  String? seriesName,  String? descriptionPlain)?  book,TResult? Function( String? title,  String? titleIgnorePrefix,  String? author,  String? description,  DateTime? releaseDate,  List<String> genres,  Uri? feedUrl,  Uri? imageUrl,  Uri? itunesPageUrl,  int? itunesId,  int? itunesArtistId,  bool explicit,  String? language)?  podcast,}) {final _that = this;
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>({TResult? Function( String? title,  String? titleIgnorePrefix,  String? subtitle,  List<Author>? authors,  List<String>? narrators, @JsonKey(readValue: _readSeries)  List<Series>? series,  List<String> genres,  String? publishedYear,  String? publishedDate,  String? publisher,  String? description,  String? isbn,  String? asin,  String? language,  bool explicit,  bool? abridged,  String? authorName,  String? authorNameLF,  String? narratorName,  String? seriesName,  String? descriptionPlain)?  book,TResult? Function( String? title,  String? titleIgnorePrefix,  String? author,  String? description,  DateTime? releaseDate,  List<String> genres,  Uri? feedUrl,  Uri? imageUrl,  Uri? itunesPageUrl,  String? itunesId,  String? itunesArtistId,  bool explicit,  String? language)?  podcast,}) {final _that = this;
 switch (_that) {
 case BookMetadata() when book != null:
 return book(_that.title,_that.titleIgnorePrefix,_that.subtitle,_that.authors,_that.narrators,_that.series,_that.genres,_that.publishedYear,_that.publishedDate,_that.publisher,_that.description,_that.isbn,_that.asin,_that.language,_that.explicit,_that.abridged,_that.authorName,_that.authorNameLF,_that.narratorName,_that.seriesName,_that.descriptionPlain);case PodcastMetadata() when podcast != null:
@@ -398,8 +398,8 @@ class PodcastMetadata extends MediaMetadata {
  final  Uri? feedUrl;
  final  Uri? imageUrl;
  final  Uri? itunesPageUrl;
- final  int? itunesId;
- final  int? itunesArtistId;
+ final  String? itunesId;
+ final  String? itunesArtistId;
 @override@JsonKey() final  bool explicit;
 @override final  String? language;
 
@@ -440,7 +440,7 @@ abstract mixin class $PodcastMetadataCopyWith<$Res> implements $MediaMetadataCop
   factory $PodcastMetadataCopyWith(PodcastMetadata value, $Res Function(PodcastMetadata) _then) = _$PodcastMetadataCopyWithImpl;
 @override @useResult
 $Res call({
- String? title, String? titleIgnorePrefix, String? author, String? description, DateTime? releaseDate, List<String> genres, Uri? feedUrl, Uri? imageUrl, Uri? itunesPageUrl, int? itunesId, int? itunesArtistId, bool explicit, String? language
+ String? title, String? titleIgnorePrefix, String? author, String? description, DateTime? releaseDate, List<String> genres, Uri? feedUrl, Uri? imageUrl, Uri? itunesPageUrl, String? itunesId, String? itunesArtistId, bool explicit, String? language
 });
 
 
@@ -469,8 +469,8 @@ as List<String>,feedUrl: freezed == feedUrl ? _self.feedUrl : feedUrl // ignore:
 as Uri?,imageUrl: freezed == imageUrl ? _self.imageUrl : imageUrl // ignore: cast_nullable_to_non_nullable
 as Uri?,itunesPageUrl: freezed == itunesPageUrl ? _self.itunesPageUrl : itunesPageUrl // ignore: cast_nullable_to_non_nullable
 as Uri?,itunesId: freezed == itunesId ? _self.itunesId : itunesId // ignore: cast_nullable_to_non_nullable
-as int?,itunesArtistId: freezed == itunesArtistId ? _self.itunesArtistId : itunesArtistId // ignore: cast_nullable_to_non_nullable
-as int?,explicit: null == explicit ? _self.explicit : explicit // ignore: cast_nullable_to_non_nullable
+as String?,itunesArtistId: freezed == itunesArtistId ? _self.itunesArtistId : itunesArtistId // ignore: cast_nullable_to_non_nullable
+as String?,explicit: null == explicit ? _self.explicit : explicit // ignore: cast_nullable_to_non_nullable
 as bool,language: freezed == language ? _self.language : language // ignore: cast_nullable_to_non_nullable
 as String?,
   ));

--- a/packages/abs_api/lib/src/models/media_metadata.g.dart
+++ b/packages/abs_api/lib/src/models/media_metadata.g.dart
@@ -88,8 +88,8 @@ PodcastMetadata _$PodcastMetadataFromJson(Map<String, dynamic> json) =>
       itunesPageUrl: json['itunesPageUrl'] == null
           ? null
           : Uri.parse(json['itunesPageUrl'] as String),
-      itunesId: (json['itunesId'] as num?)?.toInt(),
-      itunesArtistId: (json['itunesArtistId'] as num?)?.toInt(),
+      itunesId: json['itunesId'] as String?,
+      itunesArtistId: json['itunesArtistId'] as String?,
       explicit: json['explicit'] as bool? ?? false,
       language: json['language'] as String?,
       $type: json['runtimeType'] as String?,


### PR DESCRIPTION
## What does this PR do?

fixes crash when parsing podcast metadata `itunesId`/`itunesArtistId`

Closes #44

## Type of Change

- [x] Bug fix

## Checklist

- [x] `dart format .` and `dart fix --apply` have been run
- [x] No lint errors or warnings (infos for TODOs are okay)
- [x] Code generation has been run if models or providers were changed (`dart run build_runner build`)
- [x] No `print` statements introduced
- [x] Tested against an Audiobookshelf server