### PR TITLE
Feat podcast episode download support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,11 +10,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Support for downloading podcast episodes for offline playback
+- Display queue position for pending downloads in the downloads list
 
 ### Fixed
 
 - Download queue race condition
 - Dismiss download notification on cancel
+- Ensure downloads run and display in order based on queue time
 
 ## [v0.4.6] - 2026-06-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Support for downloading podcast episodes for offline playback
+
+### Fixed
+
+- Download queue race condition
+- Dismiss download notification on cancel
+
 ## [v0.4.6] - 2026-06-27
 
 ### Added

--- a/lib/features/downloads/logic/download_engine.dart
+++ b/lib/features/downloads/logic/download_engine.dart
@@ -39,7 +39,7 @@ class DownloadEngine extends _$DownloadEngine {
     }
 
     final trackTokens = <int, CancelToken>{};
-    _tokens[item.libraryItemId] = trackTokens;
+    _tokens[item.key] = trackTokens;
 
     var current = item.copyWith(status: .downloading);
     yield current;
@@ -108,7 +108,7 @@ class DownloadEngine extends _$DownloadEngine {
           current = current.copyWith(tracks: updatedTracks);
           yield current;
 
-          if (!_tokens.containsKey(item.libraryItemId)) {
+          if (!_tokens.containsKey(item.key)) {
             await sink.close();
             yield current.copyWith(status: .paused);
             return;
@@ -132,12 +132,12 @@ class DownloadEngine extends _$DownloadEngine {
         );
         await sink.close();
         if (CancelToken.isCancel(e)) {
-          _tokens.remove(item.libraryItemId);
+          _tokens.remove(item.key);
           yield current.copyWith(status: .paused);
           return;
         }
 
-        _tokens.remove(item.libraryItemId);
+        _tokens.remove(item.key);
         yield current.copyWith(status: .failed);
         return;
       } catch (e, st) {
@@ -150,13 +150,13 @@ class DownloadEngine extends _$DownloadEngine {
           stackTrace: error.stackTrace,
         );
         await sink.close();
-        _tokens.remove(item.libraryItemId);
+        _tokens.remove(item.key);
         yield current.copyWith(status: .failed);
         return;
       }
     }
 
-    _tokens.remove(item.libraryItemId);
+    _tokens.remove(item.key);
     yield current.copyWith(status: .completed);
   }
 
@@ -180,10 +180,10 @@ class DownloadEngine extends _$DownloadEngine {
     } on AppError catch (_) {}
   }
 
-  void cancel(String itemId) {
-    _coverTokens[itemId]?.cancel('cancelled');
-    _coverTokens.remove(itemId);
-    final map = _tokens.remove(itemId);
+  void cancel(String key) {
+    _coverTokens[key]?.cancel('cancelled');
+    _coverTokens.remove(key);
+    final map = _tokens.remove(key);
     if (map == null) return;
     for (final t in map.values) {
       t.cancel('cancelled');

--- a/lib/features/downloads/logic/download_engine.g.dart
+++ b/lib/features/downloads/logic/download_engine.g.dart
@@ -41,7 +41,7 @@ final class DownloadEngineProvider
   }
 }
 
-String _$downloadEngineHash() => r'd38e92cb6bbc547bba9213edca280861481c1d91';
+String _$downloadEngineHash() => r'e7b0de7265ab608955e226b76aa346962ab8427d';
 
 abstract class _$DownloadEngine extends $Notifier<void> {
   void build();

--- a/lib/features/downloads/logic/download_extensions.dart
+++ b/lib/features/downloads/logic/download_extensions.dart
@@ -1,0 +1,100 @@
+import 'package:abs_api/abs_api.dart';
+import 'package:storii/app/init.dart';
+import 'package:storii/features/downloads/logic/downloads_filesystem_helper.dart';
+import 'package:storii/features/downloads/models/download_item.dart';
+import 'package:storii/shared/helpers/abs_model_extensions.dart';
+import 'package:storii/shared/helpers/extensions.dart';
+
+extension ToDownloadItemX on LibraryItem {
+  Future<DownloadItem> toDownloadItem({
+    required String userId,
+    required Uri serverUrl,
+    DownloadItem? existing,
+  }) async {
+    final filesystem = DownloadsFilesystemHelper();
+    final downloadTracks = await Future.wait(
+      tracks.map((track) async {
+        final path = await filesystem.trackPath(
+          itemTitle: title ?? id,
+          filename: track.metadata?.filename ?? track.index.toString(),
+        );
+        final prev = existing?.tracks.firstWhereOrNull(
+          (dt) => dt.audioTrack.index == track.index,
+        );
+
+        final intact =
+            prev?.status == .completed && await filesystem.fileIntact(path);
+
+        final existingBytes = await filesystem.existingBytes(path);
+
+        final audioFile = audioFiles.firstWhere((f) => f.index == track.index);
+        return DownloadTrack(
+          audioTrack: track,
+          localPath: path,
+          ino: audioFile.ino,
+          status: intact ? .completed : (existingBytes > 0 ? .paused : .queued),
+          bytesReceived: existingBytes,
+          bytesTotal: audioFile.metadata.size,
+        );
+      }),
+    );
+
+    final downloadItem =
+        existing?.copyWith(tracks: downloadTracks, status: .queued) ??
+        DownloadItem(
+          libraryItemId: id,
+          title: title ?? id,
+          author: authorName ?? l10n.noAuthor,
+          tracks: downloadTracks,
+          startedAt: DateTime.now(),
+          serverUrl: serverUrl,
+          userId: userId,
+        );
+    return downloadItem;
+  }
+}
+
+extension ToEpisodeDownloadItemX on PodcastEpisode {
+  Future<DownloadItem> toDownloadItem({
+    required String userId,
+    required Uri serverUrl,
+    DownloadItem? existing,
+    required String itemTitle,
+  }) async {
+    if (audioTrack == null) throw 'No audio track';
+
+    final filesystem = DownloadsFilesystemHelper();
+    final path = await filesystem.trackPath(
+      itemTitle: itemTitle,
+      filename: audioFile.metadata.filename,
+    );
+
+    final prev = existing?.tracks.firstWhereOrNull(
+      (dt) => dt.ino == audioFile.ino,
+    );
+    final intact =
+        prev?.status == .completed && await filesystem.fileIntact(path);
+    final existingBytes = await filesystem.existingBytes(path);
+
+    final track = DownloadTrack(
+      audioTrack: audioTrack!,
+      localPath: path,
+      ino: audioFile.ino,
+      status: intact ? .completed : (existingBytes > 0 ? .paused : .queued),
+      bytesReceived: existingBytes,
+      bytesTotal: audioFile.metadata.size,
+    );
+
+    return existing?.copyWith(tracks: [track], status: .queued) ??
+        DownloadItem(
+          libraryItemId: libraryItemId,
+          title: title ?? id,
+          author: '',
+          tracks: [track],
+          startedAt: DateTime.now(),
+          serverUrl: serverUrl,
+          userId: userId,
+          episodeId: id,
+        );
+  }
+}

--- a/lib/features/downloads/logic/download_extensions.dart
+++ b/lib/features/downloads/logic/download_extensions.dart
@@ -40,7 +40,11 @@ extension ToDownloadItemX on LibraryItem {
     );
 
     final downloadItem =
-        existing?.copyWith(tracks: downloadTracks, status: .queued) ??
+        existing?.copyWith(
+          tracks: downloadTracks,
+          status: .queued,
+          startedAt: DateTime.now(),
+        ) ??
         DownloadItem(
           libraryItemId: id,
           title: title ?? id,
@@ -85,7 +89,11 @@ extension ToEpisodeDownloadItemX on PodcastEpisode {
       bytesTotal: audioFile.metadata.size,
     );
 
-    return existing?.copyWith(tracks: [track], status: .queued) ??
+    return existing?.copyWith(
+          tracks: [track],
+          status: .queued,
+          startedAt: DateTime.now(),
+        ) ??
         DownloadItem(
           libraryItemId: libraryItemId,
           title: title ?? id,

--- a/lib/features/downloads/logic/download_queue.dart
+++ b/lib/features/downloads/logic/download_queue.dart
@@ -19,7 +19,7 @@ part 'download_queue.g.dart';
 class DownloadQueue extends _$DownloadQueue {
   DownloadsStore get _store => ref.read(downloadsStoreProvider.notifier);
 
-  bool _processing = false;
+  Completer<void>? _processing;
 
   @override
   List<String> build() => [];
@@ -53,21 +53,17 @@ class DownloadQueue extends _$DownloadQueue {
   }
 
   Future<void> _processQueue() async {
-    if (_processing) return;
-    _processing = true;
+    if (_processing != null) return;
+    _processing = Completer<void>();
 
-    // TODO: _processing is a plain bool field. If pause() or delete() is called
-    // while _processQueue is awaiting _downloadItem, _processing is set to false
-    // but the current await has already captured the old value. The queue can
-    // then re-enter _processQueue from a new enqueue() before the prior stream
-    // fully completes
     while (state.isNotEmpty) {
       final id = state.first;
       await _downloadItem(id);
       state = state.where((i) => i != id).toList();
     }
 
-    _processing = false;
+    _processing?.complete();
+    _processing = null;
   }
 
   Future<void> _downloadItem(String libraryItemId) async {
@@ -129,11 +125,13 @@ class DownloadQueue extends _$DownloadQueue {
 
   Future<void> pause(String id) async {
     ref.read(downloadEngineProvider.notifier).cancel(id);
-    _processing = false;
+    final processing = _processing;
     state = state.where((i) => i != id).toList();
     final downloads = _store.getAll();
     final item = downloads[id];
     if (item != null) await _store.save(item.copyWith(status: .paused));
+
+    await processing?.future;
 
     await DownloadsNotificationService.instance.stopForeground();
     await DownloadsNotificationService.instance.showProgressNotification(
@@ -148,7 +146,7 @@ class DownloadQueue extends _$DownloadQueue {
 
   Future<void> delete(String id) async {
     ref.read(downloadEngineProvider.notifier).cancel(id);
-    _processing = false;
+    final processing = _processing;
     await DownloadsNotificationService.instance.stopForeground();
     await DownloadsNotificationService.instance.dismiss();
     state = state.where((i) => i != id).toList();
@@ -159,6 +157,8 @@ class DownloadQueue extends _$DownloadQueue {
     }
     await ref.read(itemsCacheProvider.notifier).delete(id);
     await _store.remove(id);
+
+    await processing?.future;
   }
 
   Future<void> _setStatus(String id, DownloadStatus status) async {

--- a/lib/features/downloads/logic/download_queue.dart
+++ b/lib/features/downloads/logic/download_queue.dart
@@ -1,14 +1,17 @@
 import 'dart:async';
+import 'dart:io';
 
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 import 'package:storii/app/logs/log_service.dart';
 import 'package:storii/app/providers/authenticated_user_provider.dart';
 import 'package:storii/app/providers/settings_provider.dart';
 import 'package:storii/features/downloads/logic/download_engine.dart';
+import 'package:storii/features/downloads/logic/download_extensions.dart';
 import 'package:storii/features/downloads/logic/downloads_filesystem_helper.dart';
 import 'package:storii/features/downloads/logic/downloads_notification_service.dart';
 import 'package:storii/features/downloads/models/download_item.dart';
 import 'package:storii/features/item/logic/item_detail_provider.dart';
+import 'package:storii/shared/helpers/abs_model_extensions.dart';
 import 'package:storii/shared/helpers/app_error.dart';
 import 'package:storii/storage/local/downloads_store.dart';
 import 'package:storii/storage/local/items_cache.dart';
@@ -24,26 +27,38 @@ class DownloadQueue extends _$DownloadQueue {
   @override
   List<String> build() => [];
 
-  Future<void> enqueue(String libraryItemId) async {
-    if (state.contains(libraryItemId)) return;
-
+  Future<void> enqueue(String libraryItemId, String? episodeId) async {
+    final key = mediaItemIdKey(libraryItemId, episodeId);
+    if (state.contains(key)) return;
     try {
       final item = await ref.read(itemDetailProvider(libraryItemId).future);
       await ref.read(itemsCacheProvider.notifier).put(item);
 
       final user = await ref.read(authenticatedUserProvider.future);
 
-      final downloadItem = await item.toDownloadItem(
-        userId: user.id,
-        serverUrl: user.serverUrl,
-      );
+      final DownloadItem downloadItem;
+
+      if (item.isPodcast) {
+        final episode = item.episodes.firstWhere((e) => e.id == episodeId);
+        downloadItem = await episode.toDownloadItem(
+          userId: user.id,
+          serverUrl: user.serverUrl,
+          itemTitle: item.title ?? libraryItemId,
+        );
+      } else {
+        downloadItem = await item.toDownloadItem(
+          userId: user.id,
+          serverUrl: user.serverUrl,
+        );
+      }
+
       await _store.save(downloadItem);
-      state = [...state, libraryItemId];
+      state = [...state, key];
       await _processQueue();
     } catch (e, st) {
       final error = AppError.from(e, st);
       LogService.log(
-        'Failed to enqueue $libraryItemId: ${error.message}',
+        'Failed to enqueue item: ${error.message}',
         source: 'DownloadQueue',
         level: .error,
         originalError: error.originalError,
@@ -57,19 +72,19 @@ class DownloadQueue extends _$DownloadQueue {
     _processing = Completer<void>();
 
     while (state.isNotEmpty) {
-      final id = state.first;
-      await _downloadItem(id);
-      state = state.where((i) => i != id).toList();
+      final key = state.first;
+      await _download(key);
+      state = state.where((i) => i != key).toList();
     }
 
     _processing?.complete();
     _processing = null;
   }
 
-  Future<void> _downloadItem(String libraryItemId) async {
+  Future<void> _download(String mediaItemKey) async {
     try {
       final downloads = _store.getAll();
-      final downloadItem = downloads[libraryItemId];
+      final downloadItem = downloads[mediaItemKey];
       if (downloadItem == null) return;
 
       await DownloadsNotificationService.instance.requestPermission();
@@ -78,10 +93,12 @@ class DownloadQueue extends _$DownloadQueue {
       );
 
       final user = await ref.read(authenticatedUserProvider.future);
-      await for (final updated
-          in ref
-              .read(downloadEngineProvider.notifier)
-              .downloadItem(item: downloadItem, user: user)) {
+
+      final stream = ref
+          .read(downloadEngineProvider.notifier)
+          .downloadItem(item: downloadItem, user: user);
+
+      await for (final updated in stream) {
         await _store.save(updated);
 
         await DownloadsNotificationService.instance.showProgressNotification(
@@ -101,19 +118,19 @@ class DownloadQueue extends _$DownloadQueue {
     } catch (e, st) {
       final error = AppError.from(e, st);
       LogService.log(
-        'Download failed for $libraryItemId: ${error.message}',
+        'Download failed for $mediaItemKey: ${error.message}',
         source: 'DownloadQueue',
         level: .error,
         originalError: error.originalError,
         stackTrace: error.stackTrace,
       );
-      await _setStatus(libraryItemId, .failed);
+      await _setStatus(mediaItemKey, .failed);
 
       await DownloadsNotificationService.instance.stopForeground();
       await DownloadsNotificationService.instance.showProgressNotification(
         title:
-            ref.read(downloadsStoreProvider).value?[libraryItemId]?.title ??
-            libraryItemId,
+            ref.read(downloadsStoreProvider).value?[mediaItemKey]?.title ??
+            mediaItemKey,
         progress: 0,
         isComplete: false,
         isFailed: true,
@@ -144,19 +161,29 @@ class DownloadQueue extends _$DownloadQueue {
     );
   }
 
-  Future<void> delete(String id) async {
-    ref.read(downloadEngineProvider.notifier).cancel(id);
+  Future<void> delete(String id, String? episodeId) async {
+    final key = mediaItemIdKey(id, episodeId);
+    ref.read(downloadEngineProvider.notifier).cancel(key);
     final processing = _processing;
     await DownloadsNotificationService.instance.stopForeground();
     await DownloadsNotificationService.instance.dismiss();
-    state = state.where((i) => i != id).toList();
+    state = state.where((i) => i != key).toList();
     final downloads = _store.getAll();
-    final item = downloads[id];
+    final item = downloads[key];
     if (item != null) {
-      await ref.read(downloadsFsHelperProvider).deleteItem(item.title);
+      if (item.episodeId != null) {
+        for (final track in item.tracks) {
+          final file = File(track.localPath);
+          if (await file.exists()) await file.delete();
+        }
+      } else {
+        await ref.read(downloadsFsHelperProvider).deleteItem(item.title);
+      }
     }
-    await ref.read(itemsCacheProvider.notifier).delete(id);
-    await _store.remove(id);
+    if (episodeId == null) {
+      await ref.read(itemsCacheProvider.notifier).delete(id);
+    }
+    await _store.remove(key);
 
     await processing?.future;
   }

--- a/lib/features/downloads/logic/download_queue.dart
+++ b/lib/features/downloads/logic/download_queue.dart
@@ -149,9 +149,8 @@ class DownloadQueue extends _$DownloadQueue {
   Future<void> delete(String id) async {
     ref.read(downloadEngineProvider.notifier).cancel(id);
     _processing = false;
-    // TODO: Notification didn't go away on delete; need to cancel notification
-    // by calling _plugin.cancel(notificationId) or dismiss notification
     await DownloadsNotificationService.instance.stopForeground();
+    await DownloadsNotificationService.instance.dismiss();
     state = state.where((i) => i != id).toList();
     final downloads = _store.getAll();
     final item = downloads[id];

--- a/lib/features/downloads/logic/download_queue.dart
+++ b/lib/features/downloads/logic/download_queue.dart
@@ -25,7 +25,26 @@ class DownloadQueue extends _$DownloadQueue {
   Completer<void>? _processing;
 
   @override
-  List<String> build() => [];
+  List<String> build() {
+    final downloads = _store.getAll();
+    final active =
+        downloads.values
+            .where(
+              (item) => item.status == .queued || item.status == .downloading,
+            )
+            .toList()
+          ..sort(
+            (a, b) => (a.startedAt ?? DateTime.now()).compareTo(
+              b.startedAt ?? DateTime.now(),
+            ),
+          );
+
+    final keys = active.map((item) => item.key).toList();
+    if (keys.isNotEmpty) {
+      Future.microtask(_processQueue);
+    }
+    return keys;
+  }
 
   Future<void> enqueue(String libraryItemId, String? episodeId) async {
     final key = mediaItemIdKey(libraryItemId, episodeId);
@@ -35,6 +54,7 @@ class DownloadQueue extends _$DownloadQueue {
       await ref.read(itemsCacheProvider.notifier).put(item);
 
       final user = await ref.read(authenticatedUserProvider.future);
+      final existing = _store.getAll()[key];
 
       final DownloadItem downloadItem;
 
@@ -44,11 +64,13 @@ class DownloadQueue extends _$DownloadQueue {
           userId: user.id,
           serverUrl: user.serverUrl,
           itemTitle: item.title ?? libraryItemId,
+          existing: existing,
         );
       } else {
         downloadItem = await item.toDownloadItem(
           userId: user.id,
           serverUrl: user.serverUrl,
+          existing: existing,
         );
       }
 

--- a/lib/features/downloads/logic/download_queue.g.dart
+++ b/lib/features/downloads/logic/download_queue.g.dart
@@ -41,7 +41,7 @@ final class DownloadQueueProvider
   }
 }
 
-String _$downloadQueueHash() => r'56d8de6c86902fe0189510c1b9da5aa8b4150373';
+String _$downloadQueueHash() => r'0a61e9739637595703fe0270463eed76bdc5284d';
 
 abstract class _$DownloadQueue extends $Notifier<List<String>> {
   List<String> build();

--- a/lib/features/downloads/logic/download_queue.g.dart
+++ b/lib/features/downloads/logic/download_queue.g.dart
@@ -41,7 +41,7 @@ final class DownloadQueueProvider
   }
 }
 
-String _$downloadQueueHash() => r'998c7a2ed373c4ea3dbbd51502bb55e65c6b0936';
+String _$downloadQueueHash() => r'5627014f0450de12786b952b90427874a29865cd';
 
 abstract class _$DownloadQueue extends $Notifier<List<String>> {
   List<String> build();

--- a/lib/features/downloads/logic/download_queue.g.dart
+++ b/lib/features/downloads/logic/download_queue.g.dart
@@ -41,7 +41,7 @@ final class DownloadQueueProvider
   }
 }
 
-String _$downloadQueueHash() => r'5627014f0450de12786b952b90427874a29865cd';
+String _$downloadQueueHash() => r'958093ba4cc19a5f830a2eb538010e65f99e276d';
 
 abstract class _$DownloadQueue extends $Notifier<List<String>> {
   List<String> build();

--- a/lib/features/downloads/logic/download_queue.g.dart
+++ b/lib/features/downloads/logic/download_queue.g.dart
@@ -41,7 +41,7 @@ final class DownloadQueueProvider
   }
 }
 
-String _$downloadQueueHash() => r'958093ba4cc19a5f830a2eb538010e65f99e276d';
+String _$downloadQueueHash() => r'56d8de6c86902fe0189510c1b9da5aa8b4150373';
 
 abstract class _$DownloadQueue extends $Notifier<List<String>> {
   List<String> build();

--- a/lib/features/downloads/logic/downloads_filesystem_helper.dart
+++ b/lib/features/downloads/logic/downloads_filesystem_helper.dart
@@ -1,15 +1,11 @@
 import 'dart:io';
 import 'dart:typed_data';
 
-import 'package:abs_api/abs_api.dart';
 import 'package:path/path.dart' as p;
 import 'package:path_provider/path_provider.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 import 'package:storii/app/config/constants.dart';
-import 'package:storii/app/init.dart';
 import 'package:storii/features/downloads/models/download_item.dart';
-import 'package:storii/shared/helpers/abs_model_extensions.dart';
-import 'package:storii/shared/helpers/extensions.dart';
 
 part 'downloads_filesystem_helper.g.dart';
 
@@ -125,54 +121,5 @@ class DownloadsFilesystemHelper {
     return cleaned.length > _maxNameLength
         ? cleaned.substring(0, _maxNameLength)
         : cleaned;
-  }
-}
-
-extension ToDownloadItemX on LibraryItem {
-  Future<DownloadItem> toDownloadItem({
-    required String userId,
-    required Uri serverUrl,
-    DownloadItem? existing,
-  }) async {
-    final filesystem = DownloadsFilesystemHelper();
-    final downloadTracks = await Future.wait(
-      tracks.map((track) async {
-        final path = await filesystem.trackPath(
-          itemTitle: title ?? id,
-          filename: track.metadata?.filename ?? track.index.toString(),
-        );
-        final prev = existing?.tracks.firstWhereOrNull(
-          (dt) => dt.audioTrack.index == track.index,
-        );
-
-        final intact =
-            prev?.status == .completed && await filesystem.fileIntact(path);
-
-        final existingBytes = await filesystem.existingBytes(path);
-
-        final audioFile = audioFiles.firstWhere((f) => f.index == track.index);
-        return DownloadTrack(
-          audioTrack: track,
-          localPath: path,
-          ino: audioFile.ino,
-          status: intact ? .completed : (existingBytes > 0 ? .paused : .queued),
-          bytesReceived: existingBytes,
-          bytesTotal: audioFile.metadata.size,
-        );
-      }),
-    );
-
-    final downloadItem =
-        existing?.copyWith(tracks: downloadTracks, status: .queued) ??
-        DownloadItem(
-          libraryItemId: id,
-          title: title ?? id,
-          author: authorName ?? l10n.noAuthor,
-          tracks: downloadTracks,
-          startedAt: DateTime.now(),
-          serverUrl: serverUrl,
-          userId: userId,
-        );
-    return downloadItem;
   }
 }

--- a/lib/features/downloads/logic/downloads_notification_service.dart
+++ b/lib/features/downloads/logic/downloads_notification_service.dart
@@ -129,5 +129,7 @@ class DownloadsNotificationService {
     await _androidPlugin?.stopForegroundService();
   }
 
-  // TODO: Add cancel method to dismiss notification when download is deleted
+  Future<void> dismiss() async {
+    await _plugin.cancel(id: notificationId);
+  }
 }

--- a/lib/features/downloads/logic/downloads_provider.dart
+++ b/lib/features/downloads/logic/downloads_provider.dart
@@ -31,11 +31,33 @@ DownloadItem? downloadItem(Ref ref, String libraryItemId, [String? episodeId]) {
 @riverpod
 Stream<List<DownloadItem>> activeDownloads(Ref ref) async* {
   final downloads = await ref.watch(downloadsProvider.future);
-  yield downloads.values.where((item) => !item.isComplete).toList();
+  final list = downloads.values.where((item) => !item.isComplete).toList()
+    ..sort(
+      (a, b) => (a.startedAt ?? DateTime.now()).compareTo(
+        b.startedAt ?? DateTime.now(),
+      ),
+    );
+  yield list;
 }
 
 @riverpod
 Stream<List<DownloadItem>> completedDownloads(Ref ref) async* {
   final downloads = await ref.watch(downloadsProvider.future);
   yield downloads.values.where((item) => item.isComplete).toList();
+}
+
+@riverpod
+Future<int?> downloadQueuePosition(
+  Ref ref,
+  String libraryItemId, [
+  String? episodeId,
+]) async {
+  final key = mediaItemIdKey(libraryItemId, episodeId);
+  final queuedItems = (await ref.watch(
+    activeDownloadsProvider.selectAsync(
+      (s) => s.where((i) => i.status == .queued),
+    ),
+  )).toList();
+  final index = queuedItems.indexWhere((item) => item.key == key);
+  return index != -1 ? index + 1 : null;
 }

--- a/lib/features/downloads/logic/downloads_provider.dart
+++ b/lib/features/downloads/logic/downloads_provider.dart
@@ -1,5 +1,6 @@
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 import 'package:storii/features/downloads/models/download_item.dart';
+import 'package:storii/shared/helpers/abs_model_extensions.dart';
 import 'package:storii/storage/local/downloads_store.dart';
 
 part 'downloads_provider.g.dart';
@@ -22,8 +23,9 @@ class DownloadsNotifier extends _$DownloadsNotifier {
 }
 
 @riverpod
-DownloadItem? downloadItem(Ref ref, String libraryItemId) {
-  return ref.watch(downloadsProvider).value?[libraryItemId];
+DownloadItem? downloadItem(Ref ref, String libraryItemId, [String? episodeId]) {
+  final key = mediaItemIdKey(libraryItemId, episodeId);
+  return ref.watch(downloadsProvider).value?[key];
 }
 
 @riverpod

--- a/lib/features/downloads/logic/downloads_provider.g.dart
+++ b/lib/features/downloads/logic/downloads_provider.g.dart
@@ -71,7 +71,7 @@ final class DownloadItemProvider
     with $Provider<DownloadItem?> {
   DownloadItemProvider._({
     required DownloadItemFamily super.from,
-    required String super.argument,
+    required (String, String?) super.argument,
   }) : super(
          retry: null,
          name: r'downloadItemProvider',
@@ -87,7 +87,7 @@ final class DownloadItemProvider
   String toString() {
     return r'downloadItemProvider'
         ''
-        '($argument)';
+        '$argument';
   }
 
   @$internal
@@ -97,8 +97,8 @@ final class DownloadItemProvider
 
   @override
   DownloadItem? create(Ref ref) {
-    final argument = this.argument as String;
-    return downloadItem(ref, argument);
+    final argument = this.argument as (String, String?);
+    return downloadItem(ref, argument.$1, argument.$2);
   }
 
   /// {@macro riverpod.override_with_value}
@@ -120,10 +120,10 @@ final class DownloadItemProvider
   }
 }
 
-String _$downloadItemHash() => r'499beb39a7cbd2cf65e9518a2dac476c16938e06';
+String _$downloadItemHash() => r'c5e510e3296111b95c91030dd93e4b3c30f6ee44';
 
 final class DownloadItemFamily extends $Family
-    with $FunctionalFamilyOverride<DownloadItem?, String> {
+    with $FunctionalFamilyOverride<DownloadItem?, (String, String?)> {
   DownloadItemFamily._()
     : super(
         retry: null,
@@ -133,8 +133,8 @@ final class DownloadItemFamily extends $Family
         isAutoDispose: true,
       );
 
-  DownloadItemProvider call(String libraryItemId) =>
-      DownloadItemProvider._(argument: libraryItemId, from: this);
+  DownloadItemProvider call(String libraryItemId, [String? episodeId]) =>
+      DownloadItemProvider._(argument: (libraryItemId, episodeId), from: this);
 
   @override
   String toString() => r'downloadItemProvider';

--- a/lib/features/downloads/logic/downloads_provider.g.dart
+++ b/lib/features/downloads/logic/downloads_provider.g.dart
@@ -179,7 +179,7 @@ final class ActiveDownloadsProvider
   }
 }
 
-String _$activeDownloadsHash() => r'c8d98c227c5fb6b021f66faca42d3eebdfe10485';
+String _$activeDownloadsHash() => r'b21c671d3f9f0343759aff0786e2a78229ee50aa';
 
 @ProviderFor(completedDownloads)
 final completedDownloadsProvider = CompletedDownloadsProvider._();
@@ -222,3 +222,78 @@ final class CompletedDownloadsProvider
 
 String _$completedDownloadsHash() =>
     r'17580ae18ebbffb94e3e65c5bfc405ea6b07a15f';
+
+@ProviderFor(downloadQueuePosition)
+final downloadQueuePositionProvider = DownloadQueuePositionFamily._();
+
+final class DownloadQueuePositionProvider
+    extends $FunctionalProvider<AsyncValue<int?>, int?, FutureOr<int?>>
+    with $FutureModifier<int?>, $FutureProvider<int?> {
+  DownloadQueuePositionProvider._({
+    required DownloadQueuePositionFamily super.from,
+    required (String, String?) super.argument,
+  }) : super(
+         retry: null,
+         name: r'downloadQueuePositionProvider',
+         isAutoDispose: true,
+         dependencies: null,
+         $allTransitiveDependencies: null,
+       );
+
+  @override
+  String debugGetCreateSourceHash() => _$downloadQueuePositionHash();
+
+  @override
+  String toString() {
+    return r'downloadQueuePositionProvider'
+        ''
+        '$argument';
+  }
+
+  @$internal
+  @override
+  $FutureProviderElement<int?> $createElement($ProviderPointer pointer) =>
+      $FutureProviderElement(pointer);
+
+  @override
+  FutureOr<int?> create(Ref ref) {
+    final argument = this.argument as (String, String?);
+    return downloadQueuePosition(ref, argument.$1, argument.$2);
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return other is DownloadQueuePositionProvider && other.argument == argument;
+  }
+
+  @override
+  int get hashCode {
+    return argument.hashCode;
+  }
+}
+
+String _$downloadQueuePositionHash() =>
+    r'839c2b9d6667063ecf4e4ec664a3f078068cf90d';
+
+final class DownloadQueuePositionFamily extends $Family
+    with $FunctionalFamilyOverride<FutureOr<int?>, (String, String?)> {
+  DownloadQueuePositionFamily._()
+    : super(
+        retry: null,
+        name: r'downloadQueuePositionProvider',
+        dependencies: null,
+        $allTransitiveDependencies: null,
+        isAutoDispose: true,
+      );
+
+  DownloadQueuePositionProvider call(
+    String libraryItemId, [
+    String? episodeId,
+  ]) => DownloadQueuePositionProvider._(
+    argument: (libraryItemId, episodeId),
+    from: this,
+  );
+
+  @override
+  String toString() => r'downloadQueuePositionProvider';
+}

--- a/lib/features/downloads/models/download_item.dart
+++ b/lib/features/downloads/models/download_item.dart
@@ -1,6 +1,7 @@
 import 'package:abs_api/abs_api.dart';
 import 'package:freezed_annotation/freezed_annotation.dart';
 import 'package:storii/app/init.dart';
+import 'package:storii/shared/helpers/abs_model_extensions.dart';
 
 part 'download_item.freezed.dart';
 part 'download_item.g.dart';
@@ -37,10 +38,13 @@ sealed class DownloadItem with _$DownloadItem {
     required List<DownloadTrack> tracks,
     @Default(DownloadStatus.queued) DownloadStatus status,
     DateTime? startedAt,
+    String? episodeId,
   }) = _DownloadItem;
 
   factory DownloadItem.fromJson(Map<String, dynamic> json) =>
       _$DownloadItemFromJson(json);
+
+  String get key => mediaItemIdKey(libraryItemId, episodeId);
 
   double get progress {
     if (totalBytes == 0) return 0;

--- a/lib/features/downloads/models/download_item.freezed.dart
+++ b/lib/features/downloads/models/download_item.freezed.dart
@@ -305,7 +305,7 @@ $AudioTrackCopyWith<$Res> get audioTrack {
 /// @nodoc
 mixin _$DownloadItem {
 
- Uri get serverUrl; String get libraryItemId; String get userId; String get title; String get author; List<DownloadTrack> get tracks; DownloadStatus get status; DateTime? get startedAt;
+ Uri get serverUrl; String get libraryItemId; String get userId; String get title; String get author; List<DownloadTrack> get tracks; DownloadStatus get status; DateTime? get startedAt; String? get episodeId;
 /// Create a copy of DownloadItem
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -318,16 +318,16 @@ $DownloadItemCopyWith<DownloadItem> get copyWith => _$DownloadItemCopyWithImpl<D
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is DownloadItem&&(identical(other.serverUrl, serverUrl) || other.serverUrl == serverUrl)&&(identical(other.libraryItemId, libraryItemId) || other.libraryItemId == libraryItemId)&&(identical(other.userId, userId) || other.userId == userId)&&(identical(other.title, title) || other.title == title)&&(identical(other.author, author) || other.author == author)&&const DeepCollectionEquality().equals(other.tracks, tracks)&&(identical(other.status, status) || other.status == status)&&(identical(other.startedAt, startedAt) || other.startedAt == startedAt));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is DownloadItem&&(identical(other.serverUrl, serverUrl) || other.serverUrl == serverUrl)&&(identical(other.libraryItemId, libraryItemId) || other.libraryItemId == libraryItemId)&&(identical(other.userId, userId) || other.userId == userId)&&(identical(other.title, title) || other.title == title)&&(identical(other.author, author) || other.author == author)&&const DeepCollectionEquality().equals(other.tracks, tracks)&&(identical(other.status, status) || other.status == status)&&(identical(other.startedAt, startedAt) || other.startedAt == startedAt)&&(identical(other.episodeId, episodeId) || other.episodeId == episodeId));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,serverUrl,libraryItemId,userId,title,author,const DeepCollectionEquality().hash(tracks),status,startedAt);
+int get hashCode => Object.hash(runtimeType,serverUrl,libraryItemId,userId,title,author,const DeepCollectionEquality().hash(tracks),status,startedAt,episodeId);
 
 @override
 String toString() {
-  return 'DownloadItem(serverUrl: $serverUrl, libraryItemId: $libraryItemId, userId: $userId, title: $title, author: $author, tracks: $tracks, status: $status, startedAt: $startedAt)';
+  return 'DownloadItem(serverUrl: $serverUrl, libraryItemId: $libraryItemId, userId: $userId, title: $title, author: $author, tracks: $tracks, status: $status, startedAt: $startedAt, episodeId: $episodeId)';
 }
 
 
@@ -338,7 +338,7 @@ abstract mixin class $DownloadItemCopyWith<$Res>  {
   factory $DownloadItemCopyWith(DownloadItem value, $Res Function(DownloadItem) _then) = _$DownloadItemCopyWithImpl;
 @useResult
 $Res call({
- Uri serverUrl, String libraryItemId, String userId, String title, String author, List<DownloadTrack> tracks, DownloadStatus status, DateTime? startedAt
+ Uri serverUrl, String libraryItemId, String userId, String title, String author, List<DownloadTrack> tracks, DownloadStatus status, DateTime? startedAt, String? episodeId
 });
 
 
@@ -355,7 +355,7 @@ class _$DownloadItemCopyWithImpl<$Res>
 
 /// Create a copy of DownloadItem
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? serverUrl = null,Object? libraryItemId = null,Object? userId = null,Object? title = null,Object? author = null,Object? tracks = null,Object? status = null,Object? startedAt = freezed,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? serverUrl = null,Object? libraryItemId = null,Object? userId = null,Object? title = null,Object? author = null,Object? tracks = null,Object? status = null,Object? startedAt = freezed,Object? episodeId = freezed,}) {
   return _then(_self.copyWith(
 serverUrl: null == serverUrl ? _self.serverUrl : serverUrl // ignore: cast_nullable_to_non_nullable
 as Uri,libraryItemId: null == libraryItemId ? _self.libraryItemId : libraryItemId // ignore: cast_nullable_to_non_nullable
@@ -365,7 +365,8 @@ as String,author: null == author ? _self.author : author // ignore: cast_nullabl
 as String,tracks: null == tracks ? _self.tracks : tracks // ignore: cast_nullable_to_non_nullable
 as List<DownloadTrack>,status: null == status ? _self.status : status // ignore: cast_nullable_to_non_nullable
 as DownloadStatus,startedAt: freezed == startedAt ? _self.startedAt : startedAt // ignore: cast_nullable_to_non_nullable
-as DateTime?,
+as DateTime?,episodeId: freezed == episodeId ? _self.episodeId : episodeId // ignore: cast_nullable_to_non_nullable
+as String?,
   ));
 }
 
@@ -447,10 +448,10 @@ return $default(_that);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( Uri serverUrl,  String libraryItemId,  String userId,  String title,  String author,  List<DownloadTrack> tracks,  DownloadStatus status,  DateTime? startedAt)?  $default,{required TResult orElse(),}) {final _that = this;
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( Uri serverUrl,  String libraryItemId,  String userId,  String title,  String author,  List<DownloadTrack> tracks,  DownloadStatus status,  DateTime? startedAt,  String? episodeId)?  $default,{required TResult orElse(),}) {final _that = this;
 switch (_that) {
 case _DownloadItem() when $default != null:
-return $default(_that.serverUrl,_that.libraryItemId,_that.userId,_that.title,_that.author,_that.tracks,_that.status,_that.startedAt);case _:
+return $default(_that.serverUrl,_that.libraryItemId,_that.userId,_that.title,_that.author,_that.tracks,_that.status,_that.startedAt,_that.episodeId);case _:
   return orElse();
 
 }
@@ -468,10 +469,10 @@ return $default(_that.serverUrl,_that.libraryItemId,_that.userId,_that.title,_th
 /// }
 /// ```
 
-@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( Uri serverUrl,  String libraryItemId,  String userId,  String title,  String author,  List<DownloadTrack> tracks,  DownloadStatus status,  DateTime? startedAt)  $default,) {final _that = this;
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( Uri serverUrl,  String libraryItemId,  String userId,  String title,  String author,  List<DownloadTrack> tracks,  DownloadStatus status,  DateTime? startedAt,  String? episodeId)  $default,) {final _that = this;
 switch (_that) {
 case _DownloadItem():
-return $default(_that.serverUrl,_that.libraryItemId,_that.userId,_that.title,_that.author,_that.tracks,_that.status,_that.startedAt);}
+return $default(_that.serverUrl,_that.libraryItemId,_that.userId,_that.title,_that.author,_that.tracks,_that.status,_that.startedAt,_that.episodeId);}
 }
 /// A variant of `when` that fallback to returning `null`
 ///
@@ -485,10 +486,10 @@ return $default(_that.serverUrl,_that.libraryItemId,_that.userId,_that.title,_th
 /// }
 /// ```
 
-@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( Uri serverUrl,  String libraryItemId,  String userId,  String title,  String author,  List<DownloadTrack> tracks,  DownloadStatus status,  DateTime? startedAt)?  $default,) {final _that = this;
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( Uri serverUrl,  String libraryItemId,  String userId,  String title,  String author,  List<DownloadTrack> tracks,  DownloadStatus status,  DateTime? startedAt,  String? episodeId)?  $default,) {final _that = this;
 switch (_that) {
 case _DownloadItem() when $default != null:
-return $default(_that.serverUrl,_that.libraryItemId,_that.userId,_that.title,_that.author,_that.tracks,_that.status,_that.startedAt);case _:
+return $default(_that.serverUrl,_that.libraryItemId,_that.userId,_that.title,_that.author,_that.tracks,_that.status,_that.startedAt,_that.episodeId);case _:
   return null;
 
 }
@@ -500,7 +501,7 @@ return $default(_that.serverUrl,_that.libraryItemId,_that.userId,_that.title,_th
 @JsonSerializable()
 
 class _DownloadItem extends DownloadItem {
-  const _DownloadItem({required this.serverUrl, required this.libraryItemId, required this.userId, required this.title, required this.author, required final  List<DownloadTrack> tracks, this.status = DownloadStatus.queued, this.startedAt}): _tracks = tracks,super._();
+  const _DownloadItem({required this.serverUrl, required this.libraryItemId, required this.userId, required this.title, required this.author, required final  List<DownloadTrack> tracks, this.status = DownloadStatus.queued, this.startedAt, this.episodeId}): _tracks = tracks,super._();
   factory _DownloadItem.fromJson(Map<String, dynamic> json) => _$DownloadItemFromJson(json);
 
 @override final  Uri serverUrl;
@@ -517,6 +518,7 @@ class _DownloadItem extends DownloadItem {
 
 @override@JsonKey() final  DownloadStatus status;
 @override final  DateTime? startedAt;
+@override final  String? episodeId;
 
 /// Create a copy of DownloadItem
 /// with the given fields replaced by the non-null parameter values.
@@ -531,16 +533,16 @@ Map<String, dynamic> toJson() {
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is _DownloadItem&&(identical(other.serverUrl, serverUrl) || other.serverUrl == serverUrl)&&(identical(other.libraryItemId, libraryItemId) || other.libraryItemId == libraryItemId)&&(identical(other.userId, userId) || other.userId == userId)&&(identical(other.title, title) || other.title == title)&&(identical(other.author, author) || other.author == author)&&const DeepCollectionEquality().equals(other._tracks, _tracks)&&(identical(other.status, status) || other.status == status)&&(identical(other.startedAt, startedAt) || other.startedAt == startedAt));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _DownloadItem&&(identical(other.serverUrl, serverUrl) || other.serverUrl == serverUrl)&&(identical(other.libraryItemId, libraryItemId) || other.libraryItemId == libraryItemId)&&(identical(other.userId, userId) || other.userId == userId)&&(identical(other.title, title) || other.title == title)&&(identical(other.author, author) || other.author == author)&&const DeepCollectionEquality().equals(other._tracks, _tracks)&&(identical(other.status, status) || other.status == status)&&(identical(other.startedAt, startedAt) || other.startedAt == startedAt)&&(identical(other.episodeId, episodeId) || other.episodeId == episodeId));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,serverUrl,libraryItemId,userId,title,author,const DeepCollectionEquality().hash(_tracks),status,startedAt);
+int get hashCode => Object.hash(runtimeType,serverUrl,libraryItemId,userId,title,author,const DeepCollectionEquality().hash(_tracks),status,startedAt,episodeId);
 
 @override
 String toString() {
-  return 'DownloadItem(serverUrl: $serverUrl, libraryItemId: $libraryItemId, userId: $userId, title: $title, author: $author, tracks: $tracks, status: $status, startedAt: $startedAt)';
+  return 'DownloadItem(serverUrl: $serverUrl, libraryItemId: $libraryItemId, userId: $userId, title: $title, author: $author, tracks: $tracks, status: $status, startedAt: $startedAt, episodeId: $episodeId)';
 }
 
 
@@ -551,7 +553,7 @@ abstract mixin class _$DownloadItemCopyWith<$Res> implements $DownloadItemCopyWi
   factory _$DownloadItemCopyWith(_DownloadItem value, $Res Function(_DownloadItem) _then) = __$DownloadItemCopyWithImpl;
 @override @useResult
 $Res call({
- Uri serverUrl, String libraryItemId, String userId, String title, String author, List<DownloadTrack> tracks, DownloadStatus status, DateTime? startedAt
+ Uri serverUrl, String libraryItemId, String userId, String title, String author, List<DownloadTrack> tracks, DownloadStatus status, DateTime? startedAt, String? episodeId
 });
 
 
@@ -568,7 +570,7 @@ class __$DownloadItemCopyWithImpl<$Res>
 
 /// Create a copy of DownloadItem
 /// with the given fields replaced by the non-null parameter values.
-@override @pragma('vm:prefer-inline') $Res call({Object? serverUrl = null,Object? libraryItemId = null,Object? userId = null,Object? title = null,Object? author = null,Object? tracks = null,Object? status = null,Object? startedAt = freezed,}) {
+@override @pragma('vm:prefer-inline') $Res call({Object? serverUrl = null,Object? libraryItemId = null,Object? userId = null,Object? title = null,Object? author = null,Object? tracks = null,Object? status = null,Object? startedAt = freezed,Object? episodeId = freezed,}) {
   return _then(_DownloadItem(
 serverUrl: null == serverUrl ? _self.serverUrl : serverUrl // ignore: cast_nullable_to_non_nullable
 as Uri,libraryItemId: null == libraryItemId ? _self.libraryItemId : libraryItemId // ignore: cast_nullable_to_non_nullable
@@ -578,7 +580,8 @@ as String,author: null == author ? _self.author : author // ignore: cast_nullabl
 as String,tracks: null == tracks ? _self._tracks : tracks // ignore: cast_nullable_to_non_nullable
 as List<DownloadTrack>,status: null == status ? _self.status : status // ignore: cast_nullable_to_non_nullable
 as DownloadStatus,startedAt: freezed == startedAt ? _self.startedAt : startedAt // ignore: cast_nullable_to_non_nullable
-as DateTime?,
+as DateTime?,episodeId: freezed == episodeId ? _self.episodeId : episodeId // ignore: cast_nullable_to_non_nullable
+as String?,
   ));
 }
 

--- a/lib/features/downloads/models/download_item.g.dart
+++ b/lib/features/downloads/models/download_item.g.dart
@@ -54,6 +54,7 @@ _DownloadItem _$DownloadItemFromJson(Map<String, dynamic> json) =>
       startedAt: json['startedAt'] == null
           ? null
           : DateTime.parse(json['startedAt'] as String),
+      episodeId: json['episodeId'] as String?,
     );
 
 Map<String, dynamic> _$DownloadItemToJson(_DownloadItem instance) =>
@@ -66,4 +67,5 @@ Map<String, dynamic> _$DownloadItemToJson(_DownloadItem instance) =>
       'tracks': instance.tracks.map((e) => e.toJson()).toList(),
       'status': _$DownloadStatusEnumMap[instance.status]!,
       'startedAt': ?instance.startedAt?.toIso8601String(),
+      'episodeId': ?instance.episodeId,
     };

--- a/lib/features/downloads/ui/download_button.dart
+++ b/lib/features/downloads/ui/download_button.dart
@@ -61,9 +61,14 @@ class ActiveDownloadsButton extends ConsumerWidget {
 }
 
 class DownloadButton extends ConsumerWidget {
-  const DownloadButton({super.key, required this.libraryItemId});
+  const DownloadButton({
+    super.key,
+    required this.libraryItemId,
+    this.episodeId,
+  });
 
   final String libraryItemId;
+  final String? episodeId;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -71,7 +76,7 @@ class DownloadButton extends ConsumerWidget {
         ref.watch(userPermissionsProvider).value?.download ?? false;
     if (!canDownload) return const SizedBox.shrink();
 
-    final item = ref.watch(downloadItemProvider(libraryItemId));
+    final item = ref.watch(downloadItemProvider(libraryItemId, episodeId));
     final queue = ref.read(downloadQueueProvider.notifier);
     final scheme = Theme.of(context).colorScheme;
 
@@ -79,16 +84,16 @@ class DownloadButton extends ConsumerWidget {
       null => IconButton(
         tooltip: l10n.download,
         icon: const Icon(Icons.download_outlined),
-        onPressed: () => queue.enqueue(libraryItemId),
+        onPressed: () => queue.enqueue(libraryItemId, episodeId),
       ),
       .queued => IconButton(
         tooltip: l10n.queued,
         icon: Icon(Icons.schedule, color: scheme.outline),
-        onPressed: () => queue.delete(libraryItemId),
+        onPressed: () => queue.delete(libraryItemId, episodeId),
       ),
       .downloading => _ProgressButton(
         progress: item!.progress,
-        onCancel: () => queue.delete(libraryItemId),
+        onCancel: () => queue.delete(libraryItemId, episodeId),
       ),
       .completed => IconButton(
         tooltip: l10n.downloaded,
@@ -102,12 +107,12 @@ class DownloadButton extends ConsumerWidget {
       .failed => IconButton(
         tooltip: l10n.downloadFailed,
         icon: Icon(Icons.refresh, color: scheme.error),
-        onPressed: () => queue.enqueue(libraryItemId),
+        onPressed: () => queue.enqueue(libraryItemId, episodeId),
       ),
       .paused => IconButton(
         tooltip: l10n.resumeDownload,
         icon: Icon(Icons.play_circle_outline, color: scheme.tertiary),
-        onPressed: () => queue.enqueue(libraryItemId),
+        onPressed: () => queue.enqueue(libraryItemId, episodeId),
       ),
     };
   }

--- a/lib/features/downloads/ui/download_widgets.dart
+++ b/lib/features/downloads/ui/download_widgets.dart
@@ -145,12 +145,12 @@ class DownloadTileTrailingActions extends ConsumerWidget {
       .downloading || .queued => IconButton(
         icon: const Icon(Icons.pause_circle_outline),
         tooltip: l10n.pause,
-        onPressed: () => queue.pause(item.libraryItemId),
+        onPressed: () => queue.pause(item.key),
       ),
       .paused || .failed => IconButton(
         icon: const Icon(Icons.play_circle_outline),
         tooltip: l10n.resume,
-        onPressed: () => queue.enqueue(item.libraryItemId),
+        onPressed: () => queue.enqueue(item.libraryItemId, item.episodeId),
       ),
       .completed => IconButton(
         icon: Icon(
@@ -189,7 +189,9 @@ void showDownloadsDeleteDialog(
     actionLabel: l10n.remove,
     isDestructive: true,
     onTap: () async {
-      await ref.read(downloadQueueProvider.notifier).delete(item.libraryItemId);
+      await ref
+          .read(downloadQueueProvider.notifier)
+          .delete(item.libraryItemId, item.episodeId);
     },
   );
 }

--- a/lib/features/downloads/ui/download_widgets.dart
+++ b/lib/features/downloads/ui/download_widgets.dart
@@ -3,6 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:storii/app/init.dart';
 import 'package:storii/app/providers/settings_provider.dart';
 import 'package:storii/features/downloads/logic/download_queue.dart';
+import 'package:storii/features/downloads/logic/downloads_provider.dart';
 import 'package:storii/features/downloads/models/download_item.dart';
 import 'package:storii/shared/helpers/helpers.dart';
 import 'package:storii/shared/widgets/app_dialog.dart';
@@ -90,16 +91,23 @@ class DownloadStatusRow extends ConsumerWidget {
     final useBinary = ref.watch(useBinaryBytesProvider);
     final scheme = Theme.of(context).colorScheme;
     final textTheme = Theme.of(context).textTheme;
+    final queueIndex = ref
+        .watch(
+          downloadQueuePositionProvider(item.libraryItemId, item.episodeId),
+        )
+        .value;
 
     final received = formatBytes(item.receivedBytes, useBinary: useBinary);
     final total = formatBytes(item.totalBytes, useBinary: useBinary);
+
+    final queuePos = queueIndex != null ? ' #$queueIndex' : '';
 
     return switch (item.status) {
       .queued => Row(
         children: [
           Icon(Icons.schedule, color: scheme.outline, size: 12),
           const SizedBox(width: 6),
-          Text(l10n.queued, style: textTheme.labelSmall),
+          Text('${l10n.queued}$queuePos', style: textTheme.labelSmall),
         ],
       ),
       .downloading => Row(
@@ -193,5 +201,6 @@ void showDownloadsDeleteDialog(
           .read(downloadQueueProvider.notifier)
           .delete(item.libraryItemId, item.episodeId);
     },
+    unawaitedOnTap: true,
   );
 }

--- a/lib/features/downloads/ui/downloads_screen.dart
+++ b/lib/features/downloads/ui/downloads_screen.dart
@@ -246,7 +246,7 @@ class _DownloadTileState extends State<DownloadTile> {
               ),
               DownloadTileTrailingActions(item: widget.item),
               IconButton(
-                icon: Icon(isExpanded ? Icons.expand_less : Icons.expand_more),
+                icon: const Icon(Icons.more_horiz),
                 onPressed: () => setState(() {
                   isExpanded = !isExpanded;
                 }),

--- a/lib/features/item/ui/episode_action_buttons.dart
+++ b/lib/features/item/ui/episode_action_buttons.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:storii/app/init.dart';
 import 'package:storii/app/providers/media_progress_map_provider.dart';
+import 'package:storii/features/downloads/ui/download_button.dart';
 import 'package:storii/features/item/logic/progress_notifier.dart';
 import 'package:storii/features/player/ui/history_button.dart';
 import 'package:storii/shared/widgets/app_bottom_sheet.dart';
@@ -22,8 +23,10 @@ class EpisodeActionButtons extends ConsumerWidget {
     return Row(
       mainAxisAlignment: .spaceEvenly,
       children: [
-        // TODO: download podcast episode
-        // DownloadButton(libraryItemId: episode.libraryItemId),
+        DownloadButton(
+          libraryItemId: episode.libraryItemId,
+          episodeId: episode.id,
+        ),
         HistoryButton(itemId: episode.libraryItemId, episodeId: episode.id),
         if (progress?.isFinished != true)
           IconButton(

--- a/lib/features/player/logic/session_extensions.dart
+++ b/lib/features/player/logic/session_extensions.dart
@@ -131,13 +131,21 @@ extension PlaybackSessionX on PlaybackSession {
     if (tracks == null || tracks.isEmpty) return (trackPaths, null);
 
     final coverPath = await DownloadsFilesystemHelper().coverPathIfExists(
-      displayTitle ?? l10n.noTitle,
+      mediaMetadata.title ?? libraryItemId,
     );
     for (final track in tracks) {
-      final local = await DownloadsFilesystemHelper().trackPathIfExists(
-        filename: track.metadata?.filename ?? track.index.toString(),
-        itemTitle: libraryItem?.title ?? libraryItemId,
-      );
+      final String? local;
+      if (episodeId != null) {
+        local = await DownloadsFilesystemHelper().trackPathIfExists(
+          filename: displayTitle ?? episodeId!,
+          itemTitle: libraryItem?.title ?? mediaMetadata.title ?? libraryItemId,
+        );
+      } else {
+        local = await DownloadsFilesystemHelper().trackPathIfExists(
+          filename: track.metadata?.filename ?? track.index.toString(),
+          itemTitle: libraryItem?.title ?? libraryItemId,
+        );
+      }
       if (local != null) trackPaths[track.index] = local;
     }
 

--- a/lib/storage/local/downloads_store.dart
+++ b/lib/storage/local/downloads_store.dart
@@ -18,7 +18,7 @@ class DownloadsStore extends _$DownloadsStore {
       values.map((v) {
         try {
           final item = DownloadItem.fromJson(jsonDecode(v));
-          return MapEntry(item.libraryItemId, item);
+          return MapEntry(item.key, item);
         } catch (e) {
           log('Failed to decode download item: $e');
           return null;
@@ -37,7 +37,7 @@ class DownloadsStore extends _$DownloadsStore {
 
   Future<void> save(DownloadItem item) async {
     try {
-      await _box.put(item.libraryItemId, jsonEncode(item));
+      await _box.put(item.key, jsonEncode(item));
     } catch (e) {
       log('Failed to save download item [${item.title}]: $e');
     }

--- a/lib/storage/local/downloads_store.g.dart
+++ b/lib/storage/local/downloads_store.g.dart
@@ -33,7 +33,7 @@ final class DownloadsStoreProvider
   DownloadsStore create() => DownloadsStore();
 }
 
-String _$downloadsStoreHash() => r'0fe5bdbb259eef165c391c143c72dc078e686830';
+String _$downloadsStoreHash() => r'911b9d4732dddecd07c3fe85080ccd82f6a98cf1';
 
 abstract class _$DownloadsStore
     extends $StreamNotifier<Map<String, DownloadItem>> {


### PR DESCRIPTION
## What does this PR do?

### Added

- Support for downloading podcast episodes for offline playback
- Display queue position for pending downloads in the downloads list

### Fixed

- Download queue race condition
- Dismiss download notification on cancel
- Ensure downloads run and display in order based on queue time

Closes #50 

## Type of Change

- [x] Bug fix
- [x] New feature

## Checklist

- [x] `dart format .` and `dart fix --apply` have been run
- [x] No lint errors or warnings (infos for TODOs are okay)
- [x] Code generation has been run if models or providers were changed (`dart run build_runner build`)
- [x] No `print` statements introduced
- [x] Tested against an Audiobookshelf server
