### PR TITLE
Refactor/downloads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Refactored download storage to use safe ID-based paths with automatic migration from old paths
+
+### Fixed
+
+- Enable podcast episode downloads
+- Local session offline progress restoration
+- Show downloads in home screen when offline
+- Item detail provider cache fallback
+
 ## [v0.4.8] - 2026-07-01
 
 ### Fixed
@@ -361,6 +372,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Dynamic theme support
 
 [Unreleased]: https://github.com/likhithpraveenk/storii/compare/v0.4.8...HEAD
+[refactor/downloads]: https://github.com/likhithpraveenk/storii/compare/v0.4.8...refactor/downloads
 [v0.4.8]: https://github.com/likhithpraveenk/storii/compare/v0.4.7...v0.4.8
 [v0.4.7]: https://github.com/likhithpraveenk/storii/compare/v0.4.6...v0.4.7
 [v0.4.6]: https://github.com/likhithpraveenk/storii/compare/v0.4.5...v0.4.6

--- a/lib/app/config/constants.dart
+++ b/lib/app/config/constants.dart
@@ -17,3 +17,6 @@ const githubFeatureLink = '$githubLink/issues/new?template=feature_request.md';
 const appIcon = 'assets/icons/icon.png';
 
 const downloadsDir = 'downloads';
+const audiobooksSubDir = 'audiobooks';
+const podcastsSubDir = 'podcasts';
+const coverName = 'cover.jpg';

--- a/lib/app/init.dart
+++ b/lib/app/init.dart
@@ -13,7 +13,6 @@ import 'package:storii/features/downloads/logic/downloads_notification_service.d
 import 'package:storii/features/player/logic/audio_handler.dart';
 import 'package:storii/features/player/logic/audio_providers.dart';
 import 'package:storii/features/player/logic/just_audio_player.dart';
-import 'package:storii/features/player/logic/sessions_cleanup.dart';
 import 'package:storii/l10n/l10n.dart';
 
 late final AppLinks appLinks;
@@ -62,12 +61,6 @@ Future<ProviderContainer> setupProviders() async {
 
   LogService.init(container);
   audioHandler = await setupAudioService(container);
-
-  //! session cleanup (fire-and-forget, doesn't block startup)
-  final settings = container.read(appSettingsProvider);
-  if (settings.currentUser != null) {
-    unawaited(container.read(sessionsCleanupProvider.notifier).cleanup());
-  }
 
   return container;
 }

--- a/lib/app/init.dart
+++ b/lib/app/init.dart
@@ -63,10 +63,10 @@ Future<ProviderContainer> setupProviders() async {
   LogService.init(container);
   audioHandler = await setupAudioService(container);
 
-  //! session cleanup
+  //! session cleanup (fire-and-forget, doesn't block startup)
   final settings = container.read(appSettingsProvider);
   if (settings.currentUser != null) {
-    await container.read(sessionsCleanupProvider.notifier).cleanup();
+    unawaited(container.read(sessionsCleanupProvider.notifier).cleanup());
   }
 
   return container;

--- a/lib/app/models/app_settings.dart
+++ b/lib/app/models/app_settings.dart
@@ -31,6 +31,8 @@ sealed class AppSettings with _$AppSettings {
     @Default(Duration(seconds: 20)) Duration syncInterval,
 
     @Default(Duration(minutes: 1)) Duration syncIntervalMetered,
+
+    @Default(false) bool downloadPathsV2Migrated,
   }) = _AppSettings;
 
   factory AppSettings.fromJson(Map<String, dynamic> json) =>

--- a/lib/app/models/app_settings.freezed.dart
+++ b/lib/app/models/app_settings.freezed.dart
@@ -15,7 +15,7 @@ T _$identity<T>(T value) => value;
 /// @nodoc
 mixin _$AppSettings {
 
- ThemeMode get themeMode; bool get useDynamicColor;@ColorConverter() Color get appColor; DynamicSchemeVariant get schemeVariant; bool get usePureBlack; UserDomain? get currentUser; Uri? get serverUrl; int get maxLogs; bool get enableHttpLogs; Duration get syncInterval; Duration get syncIntervalMetered;
+ ThemeMode get themeMode; bool get useDynamicColor;@ColorConverter() Color get appColor; DynamicSchemeVariant get schemeVariant; bool get usePureBlack; UserDomain? get currentUser; Uri? get serverUrl; int get maxLogs; bool get enableHttpLogs; Duration get syncInterval; Duration get syncIntervalMetered; bool get downloadPathsV2Migrated;
 /// Create a copy of AppSettings
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -28,16 +28,16 @@ $AppSettingsCopyWith<AppSettings> get copyWith => _$AppSettingsCopyWithImpl<AppS
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is AppSettings&&(identical(other.themeMode, themeMode) || other.themeMode == themeMode)&&(identical(other.useDynamicColor, useDynamicColor) || other.useDynamicColor == useDynamicColor)&&(identical(other.appColor, appColor) || other.appColor == appColor)&&(identical(other.schemeVariant, schemeVariant) || other.schemeVariant == schemeVariant)&&(identical(other.usePureBlack, usePureBlack) || other.usePureBlack == usePureBlack)&&(identical(other.currentUser, currentUser) || other.currentUser == currentUser)&&(identical(other.serverUrl, serverUrl) || other.serverUrl == serverUrl)&&(identical(other.maxLogs, maxLogs) || other.maxLogs == maxLogs)&&(identical(other.enableHttpLogs, enableHttpLogs) || other.enableHttpLogs == enableHttpLogs)&&(identical(other.syncInterval, syncInterval) || other.syncInterval == syncInterval)&&(identical(other.syncIntervalMetered, syncIntervalMetered) || other.syncIntervalMetered == syncIntervalMetered));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is AppSettings&&(identical(other.themeMode, themeMode) || other.themeMode == themeMode)&&(identical(other.useDynamicColor, useDynamicColor) || other.useDynamicColor == useDynamicColor)&&(identical(other.appColor, appColor) || other.appColor == appColor)&&(identical(other.schemeVariant, schemeVariant) || other.schemeVariant == schemeVariant)&&(identical(other.usePureBlack, usePureBlack) || other.usePureBlack == usePureBlack)&&(identical(other.currentUser, currentUser) || other.currentUser == currentUser)&&(identical(other.serverUrl, serverUrl) || other.serverUrl == serverUrl)&&(identical(other.maxLogs, maxLogs) || other.maxLogs == maxLogs)&&(identical(other.enableHttpLogs, enableHttpLogs) || other.enableHttpLogs == enableHttpLogs)&&(identical(other.syncInterval, syncInterval) || other.syncInterval == syncInterval)&&(identical(other.syncIntervalMetered, syncIntervalMetered) || other.syncIntervalMetered == syncIntervalMetered)&&(identical(other.downloadPathsV2Migrated, downloadPathsV2Migrated) || other.downloadPathsV2Migrated == downloadPathsV2Migrated));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,themeMode,useDynamicColor,appColor,schemeVariant,usePureBlack,currentUser,serverUrl,maxLogs,enableHttpLogs,syncInterval,syncIntervalMetered);
+int get hashCode => Object.hash(runtimeType,themeMode,useDynamicColor,appColor,schemeVariant,usePureBlack,currentUser,serverUrl,maxLogs,enableHttpLogs,syncInterval,syncIntervalMetered,downloadPathsV2Migrated);
 
 @override
 String toString() {
-  return 'AppSettings(themeMode: $themeMode, useDynamicColor: $useDynamicColor, appColor: $appColor, schemeVariant: $schemeVariant, usePureBlack: $usePureBlack, currentUser: $currentUser, serverUrl: $serverUrl, maxLogs: $maxLogs, enableHttpLogs: $enableHttpLogs, syncInterval: $syncInterval, syncIntervalMetered: $syncIntervalMetered)';
+  return 'AppSettings(themeMode: $themeMode, useDynamicColor: $useDynamicColor, appColor: $appColor, schemeVariant: $schemeVariant, usePureBlack: $usePureBlack, currentUser: $currentUser, serverUrl: $serverUrl, maxLogs: $maxLogs, enableHttpLogs: $enableHttpLogs, syncInterval: $syncInterval, syncIntervalMetered: $syncIntervalMetered, downloadPathsV2Migrated: $downloadPathsV2Migrated)';
 }
 
 
@@ -48,7 +48,7 @@ abstract mixin class $AppSettingsCopyWith<$Res>  {
   factory $AppSettingsCopyWith(AppSettings value, $Res Function(AppSettings) _then) = _$AppSettingsCopyWithImpl;
 @useResult
 $Res call({
- ThemeMode themeMode, bool useDynamicColor,@ColorConverter() Color appColor, DynamicSchemeVariant schemeVariant, bool usePureBlack, UserDomain? currentUser, Uri? serverUrl, int maxLogs, bool enableHttpLogs, Duration syncInterval, Duration syncIntervalMetered
+ ThemeMode themeMode, bool useDynamicColor,@ColorConverter() Color appColor, DynamicSchemeVariant schemeVariant, bool usePureBlack, UserDomain? currentUser, Uri? serverUrl, int maxLogs, bool enableHttpLogs, Duration syncInterval, Duration syncIntervalMetered, bool downloadPathsV2Migrated
 });
 
 
@@ -65,7 +65,7 @@ class _$AppSettingsCopyWithImpl<$Res>
 
 /// Create a copy of AppSettings
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? themeMode = null,Object? useDynamicColor = null,Object? appColor = null,Object? schemeVariant = null,Object? usePureBlack = null,Object? currentUser = freezed,Object? serverUrl = freezed,Object? maxLogs = null,Object? enableHttpLogs = null,Object? syncInterval = null,Object? syncIntervalMetered = null,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? themeMode = null,Object? useDynamicColor = null,Object? appColor = null,Object? schemeVariant = null,Object? usePureBlack = null,Object? currentUser = freezed,Object? serverUrl = freezed,Object? maxLogs = null,Object? enableHttpLogs = null,Object? syncInterval = null,Object? syncIntervalMetered = null,Object? downloadPathsV2Migrated = null,}) {
   return _then(_self.copyWith(
 themeMode: null == themeMode ? _self.themeMode : themeMode // ignore: cast_nullable_to_non_nullable
 as ThemeMode,useDynamicColor: null == useDynamicColor ? _self.useDynamicColor : useDynamicColor // ignore: cast_nullable_to_non_nullable
@@ -78,7 +78,8 @@ as Uri?,maxLogs: null == maxLogs ? _self.maxLogs : maxLogs // ignore: cast_nulla
 as int,enableHttpLogs: null == enableHttpLogs ? _self.enableHttpLogs : enableHttpLogs // ignore: cast_nullable_to_non_nullable
 as bool,syncInterval: null == syncInterval ? _self.syncInterval : syncInterval // ignore: cast_nullable_to_non_nullable
 as Duration,syncIntervalMetered: null == syncIntervalMetered ? _self.syncIntervalMetered : syncIntervalMetered // ignore: cast_nullable_to_non_nullable
-as Duration,
+as Duration,downloadPathsV2Migrated: null == downloadPathsV2Migrated ? _self.downloadPathsV2Migrated : downloadPathsV2Migrated // ignore: cast_nullable_to_non_nullable
+as bool,
   ));
 }
 /// Create a copy of AppSettings
@@ -172,10 +173,10 @@ return $default(_that);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( ThemeMode themeMode,  bool useDynamicColor, @ColorConverter()  Color appColor,  DynamicSchemeVariant schemeVariant,  bool usePureBlack,  UserDomain? currentUser,  Uri? serverUrl,  int maxLogs,  bool enableHttpLogs,  Duration syncInterval,  Duration syncIntervalMetered)?  $default,{required TResult orElse(),}) {final _that = this;
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( ThemeMode themeMode,  bool useDynamicColor, @ColorConverter()  Color appColor,  DynamicSchemeVariant schemeVariant,  bool usePureBlack,  UserDomain? currentUser,  Uri? serverUrl,  int maxLogs,  bool enableHttpLogs,  Duration syncInterval,  Duration syncIntervalMetered,  bool downloadPathsV2Migrated)?  $default,{required TResult orElse(),}) {final _that = this;
 switch (_that) {
 case _AppSettings() when $default != null:
-return $default(_that.themeMode,_that.useDynamicColor,_that.appColor,_that.schemeVariant,_that.usePureBlack,_that.currentUser,_that.serverUrl,_that.maxLogs,_that.enableHttpLogs,_that.syncInterval,_that.syncIntervalMetered);case _:
+return $default(_that.themeMode,_that.useDynamicColor,_that.appColor,_that.schemeVariant,_that.usePureBlack,_that.currentUser,_that.serverUrl,_that.maxLogs,_that.enableHttpLogs,_that.syncInterval,_that.syncIntervalMetered,_that.downloadPathsV2Migrated);case _:
   return orElse();
 
 }
@@ -193,10 +194,10 @@ return $default(_that.themeMode,_that.useDynamicColor,_that.appColor,_that.schem
 /// }
 /// ```
 
-@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( ThemeMode themeMode,  bool useDynamicColor, @ColorConverter()  Color appColor,  DynamicSchemeVariant schemeVariant,  bool usePureBlack,  UserDomain? currentUser,  Uri? serverUrl,  int maxLogs,  bool enableHttpLogs,  Duration syncInterval,  Duration syncIntervalMetered)  $default,) {final _that = this;
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( ThemeMode themeMode,  bool useDynamicColor, @ColorConverter()  Color appColor,  DynamicSchemeVariant schemeVariant,  bool usePureBlack,  UserDomain? currentUser,  Uri? serverUrl,  int maxLogs,  bool enableHttpLogs,  Duration syncInterval,  Duration syncIntervalMetered,  bool downloadPathsV2Migrated)  $default,) {final _that = this;
 switch (_that) {
 case _AppSettings():
-return $default(_that.themeMode,_that.useDynamicColor,_that.appColor,_that.schemeVariant,_that.usePureBlack,_that.currentUser,_that.serverUrl,_that.maxLogs,_that.enableHttpLogs,_that.syncInterval,_that.syncIntervalMetered);}
+return $default(_that.themeMode,_that.useDynamicColor,_that.appColor,_that.schemeVariant,_that.usePureBlack,_that.currentUser,_that.serverUrl,_that.maxLogs,_that.enableHttpLogs,_that.syncInterval,_that.syncIntervalMetered,_that.downloadPathsV2Migrated);}
 }
 /// A variant of `when` that fallback to returning `null`
 ///
@@ -210,10 +211,10 @@ return $default(_that.themeMode,_that.useDynamicColor,_that.appColor,_that.schem
 /// }
 /// ```
 
-@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( ThemeMode themeMode,  bool useDynamicColor, @ColorConverter()  Color appColor,  DynamicSchemeVariant schemeVariant,  bool usePureBlack,  UserDomain? currentUser,  Uri? serverUrl,  int maxLogs,  bool enableHttpLogs,  Duration syncInterval,  Duration syncIntervalMetered)?  $default,) {final _that = this;
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( ThemeMode themeMode,  bool useDynamicColor, @ColorConverter()  Color appColor,  DynamicSchemeVariant schemeVariant,  bool usePureBlack,  UserDomain? currentUser,  Uri? serverUrl,  int maxLogs,  bool enableHttpLogs,  Duration syncInterval,  Duration syncIntervalMetered,  bool downloadPathsV2Migrated)?  $default,) {final _that = this;
 switch (_that) {
 case _AppSettings() when $default != null:
-return $default(_that.themeMode,_that.useDynamicColor,_that.appColor,_that.schemeVariant,_that.usePureBlack,_that.currentUser,_that.serverUrl,_that.maxLogs,_that.enableHttpLogs,_that.syncInterval,_that.syncIntervalMetered);case _:
+return $default(_that.themeMode,_that.useDynamicColor,_that.appColor,_that.schemeVariant,_that.usePureBlack,_that.currentUser,_that.serverUrl,_that.maxLogs,_that.enableHttpLogs,_that.syncInterval,_that.syncIntervalMetered,_that.downloadPathsV2Migrated);case _:
   return null;
 
 }
@@ -225,7 +226,7 @@ return $default(_that.themeMode,_that.useDynamicColor,_that.appColor,_that.schem
 @JsonSerializable()
 
 class _AppSettings implements AppSettings {
-  const _AppSettings({this.themeMode = ThemeMode.system, this.useDynamicColor = false, @ColorConverter() this.appColor = appPrimaryColor, this.schemeVariant = DynamicSchemeVariant.fidelity, this.usePureBlack = false, this.currentUser, this.serverUrl, this.maxLogs = 100, this.enableHttpLogs = false, this.syncInterval = const Duration(seconds: 20), this.syncIntervalMetered = const Duration(minutes: 1)});
+  const _AppSettings({this.themeMode = ThemeMode.system, this.useDynamicColor = false, @ColorConverter() this.appColor = appPrimaryColor, this.schemeVariant = DynamicSchemeVariant.fidelity, this.usePureBlack = false, this.currentUser, this.serverUrl, this.maxLogs = 100, this.enableHttpLogs = false, this.syncInterval = const Duration(seconds: 20), this.syncIntervalMetered = const Duration(minutes: 1), this.downloadPathsV2Migrated = false});
   factory _AppSettings.fromJson(Map<String, dynamic> json) => _$AppSettingsFromJson(json);
 
 @override@JsonKey() final  ThemeMode themeMode;
@@ -239,6 +240,7 @@ class _AppSettings implements AppSettings {
 @override@JsonKey() final  bool enableHttpLogs;
 @override@JsonKey() final  Duration syncInterval;
 @override@JsonKey() final  Duration syncIntervalMetered;
+@override@JsonKey() final  bool downloadPathsV2Migrated;
 
 /// Create a copy of AppSettings
 /// with the given fields replaced by the non-null parameter values.
@@ -253,16 +255,16 @@ Map<String, dynamic> toJson() {
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is _AppSettings&&(identical(other.themeMode, themeMode) || other.themeMode == themeMode)&&(identical(other.useDynamicColor, useDynamicColor) || other.useDynamicColor == useDynamicColor)&&(identical(other.appColor, appColor) || other.appColor == appColor)&&(identical(other.schemeVariant, schemeVariant) || other.schemeVariant == schemeVariant)&&(identical(other.usePureBlack, usePureBlack) || other.usePureBlack == usePureBlack)&&(identical(other.currentUser, currentUser) || other.currentUser == currentUser)&&(identical(other.serverUrl, serverUrl) || other.serverUrl == serverUrl)&&(identical(other.maxLogs, maxLogs) || other.maxLogs == maxLogs)&&(identical(other.enableHttpLogs, enableHttpLogs) || other.enableHttpLogs == enableHttpLogs)&&(identical(other.syncInterval, syncInterval) || other.syncInterval == syncInterval)&&(identical(other.syncIntervalMetered, syncIntervalMetered) || other.syncIntervalMetered == syncIntervalMetered));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _AppSettings&&(identical(other.themeMode, themeMode) || other.themeMode == themeMode)&&(identical(other.useDynamicColor, useDynamicColor) || other.useDynamicColor == useDynamicColor)&&(identical(other.appColor, appColor) || other.appColor == appColor)&&(identical(other.schemeVariant, schemeVariant) || other.schemeVariant == schemeVariant)&&(identical(other.usePureBlack, usePureBlack) || other.usePureBlack == usePureBlack)&&(identical(other.currentUser, currentUser) || other.currentUser == currentUser)&&(identical(other.serverUrl, serverUrl) || other.serverUrl == serverUrl)&&(identical(other.maxLogs, maxLogs) || other.maxLogs == maxLogs)&&(identical(other.enableHttpLogs, enableHttpLogs) || other.enableHttpLogs == enableHttpLogs)&&(identical(other.syncInterval, syncInterval) || other.syncInterval == syncInterval)&&(identical(other.syncIntervalMetered, syncIntervalMetered) || other.syncIntervalMetered == syncIntervalMetered)&&(identical(other.downloadPathsV2Migrated, downloadPathsV2Migrated) || other.downloadPathsV2Migrated == downloadPathsV2Migrated));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,themeMode,useDynamicColor,appColor,schemeVariant,usePureBlack,currentUser,serverUrl,maxLogs,enableHttpLogs,syncInterval,syncIntervalMetered);
+int get hashCode => Object.hash(runtimeType,themeMode,useDynamicColor,appColor,schemeVariant,usePureBlack,currentUser,serverUrl,maxLogs,enableHttpLogs,syncInterval,syncIntervalMetered,downloadPathsV2Migrated);
 
 @override
 String toString() {
-  return 'AppSettings(themeMode: $themeMode, useDynamicColor: $useDynamicColor, appColor: $appColor, schemeVariant: $schemeVariant, usePureBlack: $usePureBlack, currentUser: $currentUser, serverUrl: $serverUrl, maxLogs: $maxLogs, enableHttpLogs: $enableHttpLogs, syncInterval: $syncInterval, syncIntervalMetered: $syncIntervalMetered)';
+  return 'AppSettings(themeMode: $themeMode, useDynamicColor: $useDynamicColor, appColor: $appColor, schemeVariant: $schemeVariant, usePureBlack: $usePureBlack, currentUser: $currentUser, serverUrl: $serverUrl, maxLogs: $maxLogs, enableHttpLogs: $enableHttpLogs, syncInterval: $syncInterval, syncIntervalMetered: $syncIntervalMetered, downloadPathsV2Migrated: $downloadPathsV2Migrated)';
 }
 
 
@@ -273,7 +275,7 @@ abstract mixin class _$AppSettingsCopyWith<$Res> implements $AppSettingsCopyWith
   factory _$AppSettingsCopyWith(_AppSettings value, $Res Function(_AppSettings) _then) = __$AppSettingsCopyWithImpl;
 @override @useResult
 $Res call({
- ThemeMode themeMode, bool useDynamicColor,@ColorConverter() Color appColor, DynamicSchemeVariant schemeVariant, bool usePureBlack, UserDomain? currentUser, Uri? serverUrl, int maxLogs, bool enableHttpLogs, Duration syncInterval, Duration syncIntervalMetered
+ ThemeMode themeMode, bool useDynamicColor,@ColorConverter() Color appColor, DynamicSchemeVariant schemeVariant, bool usePureBlack, UserDomain? currentUser, Uri? serverUrl, int maxLogs, bool enableHttpLogs, Duration syncInterval, Duration syncIntervalMetered, bool downloadPathsV2Migrated
 });
 
 
@@ -290,7 +292,7 @@ class __$AppSettingsCopyWithImpl<$Res>
 
 /// Create a copy of AppSettings
 /// with the given fields replaced by the non-null parameter values.
-@override @pragma('vm:prefer-inline') $Res call({Object? themeMode = null,Object? useDynamicColor = null,Object? appColor = null,Object? schemeVariant = null,Object? usePureBlack = null,Object? currentUser = freezed,Object? serverUrl = freezed,Object? maxLogs = null,Object? enableHttpLogs = null,Object? syncInterval = null,Object? syncIntervalMetered = null,}) {
+@override @pragma('vm:prefer-inline') $Res call({Object? themeMode = null,Object? useDynamicColor = null,Object? appColor = null,Object? schemeVariant = null,Object? usePureBlack = null,Object? currentUser = freezed,Object? serverUrl = freezed,Object? maxLogs = null,Object? enableHttpLogs = null,Object? syncInterval = null,Object? syncIntervalMetered = null,Object? downloadPathsV2Migrated = null,}) {
   return _then(_AppSettings(
 themeMode: null == themeMode ? _self.themeMode : themeMode // ignore: cast_nullable_to_non_nullable
 as ThemeMode,useDynamicColor: null == useDynamicColor ? _self.useDynamicColor : useDynamicColor // ignore: cast_nullable_to_non_nullable
@@ -303,7 +305,8 @@ as Uri?,maxLogs: null == maxLogs ? _self.maxLogs : maxLogs // ignore: cast_nulla
 as int,enableHttpLogs: null == enableHttpLogs ? _self.enableHttpLogs : enableHttpLogs // ignore: cast_nullable_to_non_nullable
 as bool,syncInterval: null == syncInterval ? _self.syncInterval : syncInterval // ignore: cast_nullable_to_non_nullable
 as Duration,syncIntervalMetered: null == syncIntervalMetered ? _self.syncIntervalMetered : syncIntervalMetered // ignore: cast_nullable_to_non_nullable
-as Duration,
+as Duration,downloadPathsV2Migrated: null == downloadPathsV2Migrated ? _self.downloadPathsV2Migrated : downloadPathsV2Migrated // ignore: cast_nullable_to_non_nullable
+as bool,
   ));
 }
 

--- a/lib/app/models/app_settings.g.dart
+++ b/lib/app/models/app_settings.g.dart
@@ -37,6 +37,7 @@ _AppSettings _$AppSettingsFromJson(Map<String, dynamic> json) => _AppSettings(
   syncIntervalMetered: json['syncIntervalMetered'] == null
       ? const Duration(minutes: 1)
       : Duration(microseconds: (json['syncIntervalMetered'] as num).toInt()),
+  downloadPathsV2Migrated: json['downloadPathsV2Migrated'] as bool? ?? false,
 );
 
 Map<String, dynamic> _$AppSettingsToJson(_AppSettings instance) =>
@@ -52,6 +53,7 @@ Map<String, dynamic> _$AppSettingsToJson(_AppSettings instance) =>
       'enableHttpLogs': instance.enableHttpLogs,
       'syncInterval': instance.syncInterval.inMicroseconds,
       'syncIntervalMetered': instance.syncIntervalMetered.inMicroseconds,
+      'downloadPathsV2Migrated': instance.downloadPathsV2Migrated,
     };
 
 const _$ThemeModeEnumMap = {

--- a/lib/app/providers/connection_providers.dart
+++ b/lib/app/providers/connection_providers.dart
@@ -14,6 +14,12 @@ Stream<bool> socketStatus(Ref ref) async* {
     return;
   }
 
+  final connectionType = ref.watch(connectionTypeProvider);
+  if (connectionType == .none) {
+    yield false;
+    return;
+  }
+
   final socketApi = await ref.watch(socketApiProvider(user).future);
   yield* socketApi.isConnected;
 }

--- a/lib/app/providers/connection_providers.g.dart
+++ b/lib/app/providers/connection_providers.g.dart
@@ -40,7 +40,7 @@ final class SocketStatusProvider
   }
 }
 
-String _$socketStatusHash() => r'c5cd6a92e3767afdf9ed2d07918125accdafcb57';
+String _$socketStatusHash() => r'2ccb76e3a5fe359e7388df655020ac4e76f98a82';
 
 @ProviderFor(connectivityStream)
 final connectivityStreamProvider = ConnectivityStreamProvider._();

--- a/lib/app/providers/media_progress_map_provider.dart
+++ b/lib/app/providers/media_progress_map_provider.dart
@@ -21,35 +21,38 @@ class MediaProgressMap extends _$MediaProgressMap {
     });
     await _progressSub?.cancel();
     await _userSub?.cancel();
+    try {
+      final user = await ref.watch(authenticatedUserProvider.future);
 
-    final user = await ref.watch(authenticatedUserProvider.future);
-
-    final updatedUser = await ref.read(meApiProvider(user)).getUser();
-    final map = {
-      for (var p in updatedUser.mediaProgress)
-        mediaItemIdKey(p.libraryItemId, p.episodeId): p,
-    };
-
-    final socket = await ref.watch(socketApiProvider(user).future);
-
-    _progressSub = socket.user.onProgressUpdate.listen((event) {
-      final current = state.value ?? {};
-      state = AsyncData({
-        ...current,
-        mediaItemIdKey(event.data.libraryItemId, event.data.episodeId):
-            event.data,
-      });
-    });
-
-    _userSub = socket.user.onUserUpdated.listen((updatedUser) {
-      final newMap = {
+      final updatedUser = await ref.read(meApiProvider(user)).getUser();
+      final map = {
         for (var p in updatedUser.mediaProgress)
           mediaItemIdKey(p.libraryItemId, p.episodeId): p,
       };
-      state = AsyncData(newMap);
-    });
 
-    return map;
+      final socket = await ref.watch(socketApiProvider(user).future);
+
+      _progressSub = socket.user.onProgressUpdate.listen((event) {
+        final current = state.value ?? {};
+        state = AsyncData({
+          ...current,
+          mediaItemIdKey(event.data.libraryItemId, event.data.episodeId):
+              event.data,
+        });
+      });
+
+      _userSub = socket.user.onUserUpdated.listen((updatedUser) {
+        final newMap = {
+          for (var p in updatedUser.mediaProgress)
+            mediaItemIdKey(p.libraryItemId, p.episodeId): p,
+        };
+        state = AsyncData(newMap);
+      });
+
+      return map;
+    } catch (_) {
+      return {};
+    }
   }
 }
 

--- a/lib/app/providers/media_progress_map_provider.g.dart
+++ b/lib/app/providers/media_progress_map_provider.g.dart
@@ -34,7 +34,7 @@ final class MediaProgressMapProvider
   MediaProgressMap create() => MediaProgressMap();
 }
 
-String _$mediaProgressMapHash() => r'a79778165b7c1e3b021efdc98d1806075a2eec84';
+String _$mediaProgressMapHash() => r'c6a31768ab74f5369598914e923c2efb3f5bb91a';
 
 abstract class _$MediaProgressMap
     extends $AsyncNotifier<Map<String, MediaProgress>> {

--- a/lib/app/providers/settings_provider.g.dart
+++ b/lib/app/providers/settings_provider.g.dart
@@ -151,6 +151,9 @@ extension AppSettingsSetters on AppSettingsNotifier {
 
   Future<void> setSyncIntervalMetered(Duration value) =>
       _save(state.copyWith(syncIntervalMetered: value));
+
+  Future<void> setDownloadPathsV2Migrated(bool value) =>
+      _save(state.copyWith(downloadPathsV2Migrated: value));
 }
 
 final themeModeProvider = Provider<ThemeMode>(
@@ -206,6 +209,12 @@ final syncIntervalProvider = Provider<Duration>(
 final syncIntervalMeteredProvider = Provider<Duration>(
   (ref) => ref.watch(appSettingsProvider.select((s) => s.syncIntervalMetered)),
   name: 'syncIntervalMeteredProvider',
+);
+
+final downloadPathsV2MigratedProvider = Provider<bool>(
+  (ref) =>
+      ref.watch(appSettingsProvider.select((s) => s.downloadPathsV2Migrated)),
+  name: 'downloadPathsV2MigratedProvider',
 );
 
 // **************************************************************************

--- a/lib/features/downloads/logic/download_engine.dart
+++ b/lib/features/downloads/logic/download_engine.dart
@@ -47,8 +47,8 @@ class DownloadEngine extends _$DownloadEngine {
     final coverToken = CancelToken();
     _coverTokens[item.libraryItemId] = coverToken;
     await _downloadCover(
-      itemTitle: item.episodeId != null ? item.libraryItemId : item.title,
-      itemId: item.libraryItemId,
+      libraryItemId: item.libraryItemId,
+      isPodcast: item.episodeId != null,
       user: user,
       cancelToken: coverToken,
     );
@@ -58,98 +58,116 @@ class DownloadEngine extends _$DownloadEngine {
       final initialTrack = current.tracks[i];
       if (initialTrack.status == .completed) continue;
 
-      final cancelToken = CancelToken();
-      trackTokens[i] = cancelToken;
+      bool success = false;
+      for (int attempt = 0; attempt <= 3; attempt++) {
+        final cancelToken = CancelToken();
+        trackTokens[i] = cancelToken;
 
-      final existingBytes = await _filesystem.existingBytes(
-        initialTrack.localPath,
-      );
-
-      final sink = await _filesystem.openAppendSink(initialTrack.localPath);
-
-      try {
-        final url = user.serverUrl
-            .resolve(
-              ApiRoutes.itemAudioFileDownload(
-                item.libraryItemId,
-                initialTrack.ino,
-              ),
-            )
-            .toString();
-
-        final res = await _dio.get<ResponseBody>(
-          url,
-          options: Options(
-            headers: {
-              'Authorization': 'Bearer $token',
-              if (existingBytes > 0) 'Range': 'bytes=$existingBytes-',
-            },
-            responseType: .stream,
-          ),
-          cancelToken: cancelToken,
+        final existingBytes = await _filesystem.existingBytes(
+          initialTrack.localPath,
         );
 
-        if (res.data == null) {
-          throw StateError(
-            'No response body for track ${initialTrack.audioTrack.index} of item ${item.title}',
-          );
-        }
+        final sink = await _filesystem.openAppendSink(initialTrack.localPath);
 
-        var received = existingBytes;
-        await for (final chunk in res.data!.stream) {
-          received += chunk.length;
-          sink.add(chunk);
+        try {
+          final url = user.serverUrl
+              .resolve(
+                ApiRoutes.itemAudioFileDownload(
+                  item.libraryItemId,
+                  initialTrack.ino,
+                ),
+              )
+              .toString();
+
+          final res = await _dio.get<ResponseBody>(
+            url,
+            options: Options(
+              headers: {
+                'Authorization': 'Bearer $token',
+                if (existingBytes > 0) 'Range': 'bytes=$existingBytes-',
+              },
+              responseType: .stream,
+            ),
+            cancelToken: cancelToken,
+          );
+
+          if (res.data == null) {
+            throw StateError(
+              'No response body for track ${initialTrack.audioTrack.index} of item ${item.title}',
+            );
+          }
+
+          var received = existingBytes;
+          await for (final chunk in res.data!.stream) {
+            received += chunk.length;
+            sink.add(chunk);
+
+            final updatedTracks = [...current.tracks];
+            updatedTracks[i] = current.tracks[i].copyWith(
+              status: .downloading,
+              bytesReceived: received,
+            );
+            current = current.copyWith(tracks: updatedTracks);
+            yield current;
+
+            if (!_tokens.containsKey(item.key)) {
+              await sink.close();
+              yield current.copyWith(status: .paused);
+              return;
+            }
+          }
+
+          await sink.close();
 
           final updatedTracks = [...current.tracks];
-          updatedTracks[i] = current.tracks[i].copyWith(
-            status: .downloading,
-            bytesReceived: received,
-          );
+          updatedTracks[i] = current.tracks[i].copyWith(status: .completed);
           current = current.copyWith(tracks: updatedTracks);
           yield current;
-
-          if (!_tokens.containsKey(item.key)) {
-            await sink.close();
-            yield current.copyWith(status: .paused);
+          success = true;
+          break;
+        } on DioException catch (e, st) {
+          await sink.close();
+          if (CancelToken.isCancel(e) || attempt == 3) {
+            final error = AppError.from(e, st);
+            LogService.log(
+              error.message,
+              source: 'DownloadEngine',
+              level: .error,
+              originalError: error.originalError,
+              stackTrace: error.stackTrace,
+            );
+            if (CancelToken.isCancel(e)) {
+              _tokens.remove(item.key);
+              yield current.copyWith(status: .paused);
+              return;
+            }
+            _tokens.remove(item.key);
+            yield current.copyWith(status: .failed);
             return;
           }
-        }
-
-        await sink.close();
-
-        final updatedTracks = [...current.tracks];
-        updatedTracks[i] = current.tracks[i].copyWith(status: .completed);
-        current = current.copyWith(tracks: updatedTracks);
-        yield current;
-      } on DioException catch (e, st) {
-        final error = AppError.from(e, st);
-        LogService.log(
-          error.message,
-          source: 'DownloadEngine',
-          level: .error,
-          originalError: error.originalError,
-          stackTrace: error.stackTrace,
-        );
-        await sink.close();
-        if (CancelToken.isCancel(e)) {
+          LogService.log(
+            'Track retry $attempt for ${initialTrack.ino}',
+            source: 'DownloadEngine',
+          );
+          await Future.delayed(
+            Duration(milliseconds: [500, 1000, 2000][attempt]),
+          );
+        } catch (e, st) {
+          await sink.close();
+          final error = AppError.from(e, st);
+          LogService.log(
+            error.message,
+            source: 'DownloadEngine',
+            level: .error,
+            originalError: error.originalError,
+            stackTrace: error.stackTrace,
+          );
           _tokens.remove(item.key);
-          yield current.copyWith(status: .paused);
+          yield current.copyWith(status: .failed);
           return;
         }
-
-        _tokens.remove(item.key);
-        yield current.copyWith(status: .failed);
-        return;
-      } catch (e, st) {
-        final error = AppError.from(e, st);
-        LogService.log(
-          error.message,
-          source: 'DownloadEngine',
-          level: .error,
-          originalError: error.originalError,
-          stackTrace: error.stackTrace,
-        );
-        await sink.close();
+      }
+      if (!success) {
         _tokens.remove(item.key);
         yield current.copyWith(status: .failed);
         return;
@@ -162,20 +180,24 @@ class DownloadEngine extends _$DownloadEngine {
 
   Future<void> _downloadCover({
     required UserDomain user,
-    required String itemTitle,
-    required String itemId,
+    required String libraryItemId,
+    required bool isPodcast,
     required CancelToken cancelToken,
   }) async {
     try {
       final imageBytes = await ref.logApiCall(
         () => ref
             .read(itemApiProvider(user))
-            .getCover(libraryItemId: itemId, cancelToken: cancelToken),
+            .getCover(libraryItemId: libraryItemId, cancelToken: cancelToken),
         source: 'DownloadEngine',
-        logMessage: 'Failed to download cover for $itemTitle',
+        logMessage: 'Failed to download cover for $libraryItemId',
       );
       if (imageBytes != null) {
-        await _filesystem.saveCover(itemTitle, imageBytes);
+        if (isPodcast) {
+          await _filesystem.savePodcastCover(libraryItemId, imageBytes);
+        } else {
+          await _filesystem.saveAudiobookCover(libraryItemId, imageBytes);
+        }
       }
     } on AppError catch (_) {}
   }

--- a/lib/features/downloads/logic/download_engine.dart
+++ b/lib/features/downloads/logic/download_engine.dart
@@ -98,29 +98,38 @@ class DownloadEngine extends _$DownloadEngine {
           }
 
           var received = existingBytes;
+          int lastYieldedBytes = existingBytes;
+          const int throttleThreshold = 500 * 1024;
           await for (final chunk in res.data!.stream) {
             received += chunk.length;
             sink.add(chunk);
-
-            final updatedTracks = [...current.tracks];
-            updatedTracks[i] = current.tracks[i].copyWith(
-              status: .downloading,
-              bytesReceived: received,
-            );
-            current = current.copyWith(tracks: updatedTracks);
-            yield current;
 
             if (!_tokens.containsKey(item.key)) {
               await sink.close();
               yield current.copyWith(status: .paused);
               return;
             }
+
+            if (received - lastYieldedBytes >= throttleThreshold) {
+              lastYieldedBytes = received;
+
+              final updatedTracks = [...current.tracks];
+              updatedTracks[i] = current.tracks[i].copyWith(
+                status: .downloading,
+                bytesReceived: received,
+              );
+              current = current.copyWith(tracks: updatedTracks);
+              yield current;
+            }
           }
 
           await sink.close();
 
           final updatedTracks = [...current.tracks];
-          updatedTracks[i] = current.tracks[i].copyWith(status: .completed);
+          updatedTracks[i] = current.tracks[i].copyWith(
+            status: .completed,
+            bytesReceived: received,
+          );
           current = current.copyWith(tracks: updatedTracks);
           yield current;
           success = true;

--- a/lib/features/downloads/logic/download_engine.g.dart
+++ b/lib/features/downloads/logic/download_engine.g.dart
@@ -41,7 +41,7 @@ final class DownloadEngineProvider
   }
 }
 
-String _$downloadEngineHash() => r'1043f2cec33d6df3c845d4e255b95c3bb5abcda3';
+String _$downloadEngineHash() => r'906055590a05732e3e1dc1e6600cadeafe9a180a';
 
 abstract class _$DownloadEngine extends $Notifier<void> {
   void build();

--- a/lib/features/downloads/logic/download_extensions.dart
+++ b/lib/features/downloads/logic/download_extensions.dart
@@ -9,23 +9,24 @@ extension ToDownloadItemX on LibraryItem {
   Future<DownloadItem> toDownloadItem({
     required String userId,
     required Uri serverUrl,
+    required DownloadsFilesystemHelper fs,
     DownloadItem? existing,
   }) async {
-    final filesystem = DownloadsFilesystemHelper();
     final downloadTracks = await Future.wait(
       tracks.map((track) async {
-        final path = await filesystem.trackPath(
-          itemTitle: title ?? id,
-          filename: track.metadata?.filename ?? track.index.toString(),
+        final path = await fs.audiobookTrackPath(
+          id,
+          track.metadata?.filename ?? track.index.toString(),
         );
         final prev = existing?.tracks.firstWhereOrNull(
           (dt) => dt.audioTrack.index == track.index,
         );
 
         final intact =
-            prev?.status == .completed && await filesystem.fileIntact(path);
+            prev?.status == .completed &&
+            await fs.fileIntact(path, expectedBytes: track.metadata?.size ?? 0);
 
-        final existingBytes = await filesystem.existingBytes(path);
+        final existingBytes = await fs.existingBytes(path);
 
         final audioFile = audioFiles.firstWhere((f) => f.index == track.index);
         return DownloadTrack(
@@ -50,6 +51,7 @@ extension ToDownloadItemX on LibraryItem {
           title: title ?? id,
           author: authorName ?? l10n.noAuthor,
           tracks: downloadTracks,
+          mediaType: .audiobook,
           startedAt: DateTime.now(),
           serverUrl: serverUrl,
           userId: userId,
@@ -62,23 +64,25 @@ extension ToEpisodeDownloadItemX on PodcastEpisode {
   Future<DownloadItem> toDownloadItem({
     required String userId,
     required Uri serverUrl,
+    required DownloadsFilesystemHelper fs,
     DownloadItem? existing,
     required String itemTitle,
   }) async {
     if (audioTrack == null) throw 'No audio track';
 
-    final filesystem = DownloadsFilesystemHelper();
-    final path = await filesystem.trackPath(
-      itemTitle: itemTitle,
-      filename: audioTrack!.metadata?.filename ?? id,
+    final path = await fs.podcastTrackPath(
+      libraryItemId,
+      id,
+      audioTrack!.metadata?.filename ?? id,
     );
 
     final prev = existing?.tracks.firstWhereOrNull(
       (dt) => dt.ino == audioFile.ino,
     );
     final intact =
-        prev?.status == .completed && await filesystem.fileIntact(path);
-    final existingBytes = await filesystem.existingBytes(path);
+        prev?.status == .completed &&
+        await fs.fileIntact(path, expectedBytes: audioFile.metadata.size);
+    final existingBytes = await fs.existingBytes(path);
 
     final track = DownloadTrack(
       audioTrack: audioTrack!,
@@ -99,6 +103,7 @@ extension ToEpisodeDownloadItemX on PodcastEpisode {
           title: title ?? id,
           author: '',
           tracks: [track],
+          mediaType: .podcast,
           startedAt: DateTime.now(),
           serverUrl: serverUrl,
           userId: userId,

--- a/lib/features/downloads/logic/download_migration.dart
+++ b/lib/features/downloads/logic/download_migration.dart
@@ -1,0 +1,83 @@
+import 'dart:io';
+
+import 'package:path/path.dart' as p;
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+import 'package:storii/app/config/constants.dart';
+import 'package:storii/app/providers/settings_provider.dart';
+import 'package:storii/features/downloads/logic/downloads_filesystem_helper.dart';
+import 'package:storii/features/downloads/models/download_item.dart';
+import 'package:storii/storage/local/downloads_store.dart';
+
+part 'download_migration.g.dart';
+
+@Riverpod(keepAlive: true)
+class DownloadMigrationV2 extends _$DownloadMigrationV2 {
+  @override
+  void build() {}
+
+  Future<void> runIfNeeded() async {
+    final isV2Migrated = ref.read(downloadPathsV2MigratedProvider);
+    if (isV2Migrated) return;
+
+    final store = ref.read(downloadsStoreProvider.notifier);
+    final fs = ref.read(downloadsFsHelperProvider);
+
+    final items = store.getAll();
+
+    for (final item in items.values) {
+      await _migrateItem(item, store, fs);
+    }
+
+    await ref
+        .read(appSettingsProvider.notifier)
+        .setDownloadPathsV2Migrated(true);
+  }
+
+  Future<void> _migrateItem(
+    DownloadItem item,
+    DownloadsStore store,
+    DownloadsFilesystemHelper fs,
+  ) async {
+    final isOldStyle = item.tracks.any(
+      (t) =>
+          !t.localPath.contains('/$audiobooksSubDir/') &&
+          !t.localPath.contains('/$podcastsSubDir/'),
+    );
+    if (!isOldStyle) return;
+
+    final updatedTracks = <DownloadTrack>[];
+    for (final track in item.tracks) {
+      final newPath = item.episodeId != null
+          ? await fs.podcastTrackPath(
+              item.libraryItemId,
+              item.episodeId!,
+              p.basename(track.localPath),
+            )
+          : await fs.audiobookTrackPath(
+              item.libraryItemId,
+              p.basename(track.localPath),
+            );
+
+      final oldFile = File(track.localPath);
+      DownloadStatus newStatus = track.status;
+
+      if (await oldFile.exists()) {
+        try {
+          await Directory(p.dirname(newPath)).create(recursive: true);
+          await oldFile.rename(newPath);
+        } catch (_) {
+          try {
+            await oldFile.copy(newPath);
+            await oldFile.delete();
+          } catch (_) {
+            newStatus = .queued;
+          }
+        }
+      }
+
+      updatedTracks.add(track.copyWith(localPath: newPath, status: newStatus));
+    }
+
+    await store.save(item.copyWith(tracks: updatedTracks));
+  }
+}

--- a/lib/features/downloads/logic/download_migration.g.dart
+++ b/lib/features/downloads/logic/download_migration.g.dart
@@ -1,6 +1,6 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
-part of 'download_engine.dart';
+part of 'download_migration.dart';
 
 // **************************************************************************
 // RiverpodGenerator
@@ -9,28 +9,28 @@ part of 'download_engine.dart';
 // GENERATED CODE - DO NOT MODIFY BY HAND
 // ignore_for_file: type=lint, type=warning
 
-@ProviderFor(DownloadEngine)
-final downloadEngineProvider = DownloadEngineProvider._();
+@ProviderFor(DownloadMigrationV2)
+final downloadMigrationV2Provider = DownloadMigrationV2Provider._();
 
-final class DownloadEngineProvider
-    extends $NotifierProvider<DownloadEngine, void> {
-  DownloadEngineProvider._()
+final class DownloadMigrationV2Provider
+    extends $NotifierProvider<DownloadMigrationV2, void> {
+  DownloadMigrationV2Provider._()
     : super(
         from: null,
         argument: null,
         retry: null,
-        name: r'downloadEngineProvider',
+        name: r'downloadMigrationV2Provider',
         isAutoDispose: false,
         dependencies: null,
         $allTransitiveDependencies: null,
       );
 
   @override
-  String debugGetCreateSourceHash() => _$downloadEngineHash();
+  String debugGetCreateSourceHash() => _$downloadMigrationV2Hash();
 
   @$internal
   @override
-  DownloadEngine create() => DownloadEngine();
+  DownloadMigrationV2 create() => DownloadMigrationV2();
 
   /// {@macro riverpod.override_with_value}
   Override overrideWithValue(void value) {
@@ -41,9 +41,10 @@ final class DownloadEngineProvider
   }
 }
 
-String _$downloadEngineHash() => r'1043f2cec33d6df3c845d4e255b95c3bb5abcda3';
+String _$downloadMigrationV2Hash() =>
+    r'450db6d64ab8c4f4bcacf2203ce09a47d1b91fd9';
 
-abstract class _$DownloadEngine extends $Notifier<void> {
+abstract class _$DownloadMigrationV2 extends $Notifier<void> {
   void build();
   @$mustCallSuper
   @override

--- a/lib/features/downloads/logic/download_queue.dart
+++ b/lib/features/downloads/logic/download_queue.dart
@@ -1,5 +1,4 @@
 import 'dart:async';
-import 'dart:io';
 
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 import 'package:storii/app/logs/log_service.dart';
@@ -7,6 +6,7 @@ import 'package:storii/app/providers/authenticated_user_provider.dart';
 import 'package:storii/app/providers/settings_provider.dart';
 import 'package:storii/features/downloads/logic/download_engine.dart';
 import 'package:storii/features/downloads/logic/download_extensions.dart';
+import 'package:storii/features/downloads/logic/download_migration.dart';
 import 'package:storii/features/downloads/logic/downloads_filesystem_helper.dart';
 import 'package:storii/features/downloads/logic/downloads_notification_service.dart';
 import 'package:storii/features/downloads/models/download_item.dart';
@@ -26,6 +26,10 @@ class DownloadQueue extends _$DownloadQueue {
 
   @override
   List<String> build() {
+    Future.microtask(
+      () => ref.read(downloadMigrationV2Provider.notifier).runIfNeeded(),
+    );
+
     final downloads = _store.getAll();
     final active =
         downloads.values
@@ -55,6 +59,7 @@ class DownloadQueue extends _$DownloadQueue {
 
       final user = await ref.read(authenticatedUserProvider.future);
       final existing = _store.getAll()[key];
+      final fs = ref.read(downloadsFsHelperProvider);
 
       final DownloadItem downloadItem;
 
@@ -63,6 +68,7 @@ class DownloadQueue extends _$DownloadQueue {
         downloadItem = await episode.toDownloadItem(
           userId: user.id,
           serverUrl: user.serverUrl,
+          fs: fs,
           itemTitle: item.title ?? libraryItemId,
           existing: existing,
         );
@@ -70,6 +76,7 @@ class DownloadQueue extends _$DownloadQueue {
         downloadItem = await item.toDownloadItem(
           userId: user.id,
           serverUrl: user.serverUrl,
+          fs: fs,
           existing: existing,
         );
       }
@@ -194,16 +201,30 @@ class DownloadQueue extends _$DownloadQueue {
     final item = downloads[key];
     if (item != null) {
       if (item.episodeId != null) {
-        for (final track in item.tracks) {
-          final file = File(track.localPath);
-          if (await file.exists()) await file.delete();
+        await ref
+            .read(downloadsFsHelperProvider)
+            .deletePodcastEpisode(item.libraryItemId, item.episodeId!);
+
+        final otherEpisodes = _store.getAll().values.where(
+          (d) =>
+              d.libraryItemId == item.libraryItemId &&
+              d.episodeId != item.episodeId &&
+              d.isComplete,
+        );
+        if (otherEpisodes.isEmpty) {
+          await ref
+              .read(downloadsFsHelperProvider)
+              .deletePodcastIfEmpty(item.libraryItemId);
+          await ref
+              .read(itemsCacheProvider.notifier)
+              .delete(item.libraryItemId);
         }
       } else {
-        await ref.read(downloadsFsHelperProvider).deleteItem(item.title);
+        await ref
+            .read(downloadsFsHelperProvider)
+            .deleteAudiobook(item.libraryItemId);
+        await ref.read(itemsCacheProvider.notifier).delete(id);
       }
-    }
-    if (episodeId == null) {
-      await ref.read(itemsCacheProvider.notifier).delete(id);
     }
     await _store.remove(key);
 

--- a/lib/features/downloads/logic/download_queue.g.dart
+++ b/lib/features/downloads/logic/download_queue.g.dart
@@ -41,7 +41,7 @@ final class DownloadQueueProvider
   }
 }
 
-String _$downloadQueueHash() => r'0a61e9739637595703fe0270463eed76bdc5284d';
+String _$downloadQueueHash() => r'cdc22b67378bfe185829de069613eb4c18638a56';
 
 abstract class _$DownloadQueue extends $Notifier<List<String>> {
   List<String> build();

--- a/lib/features/downloads/logic/downloads_filesystem_helper.dart
+++ b/lib/features/downloads/logic/downloads_filesystem_helper.dart
@@ -1,6 +1,6 @@
 import 'dart:io';
-import 'dart:typed_data';
 
+import 'package:abs_api/abs_api.dart';
 import 'package:path/path.dart' as p;
 import 'package:path_provider/path_provider.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
@@ -11,70 +11,168 @@ part 'downloads_filesystem_helper.g.dart';
 
 @Riverpod(keepAlive: true)
 DownloadsFilesystemHelper downloadsFsHelper(Ref ref) {
-  return DownloadsFilesystemHelper();
+  return const DownloadsFilesystemHelper();
 }
 
 class DownloadsFilesystemHelper {
-  Directory? _cachedRoot;
-
-  static const int _maxNameLength = 200;
+  const DownloadsFilesystemHelper();
 
   Future<Directory> rootDirectory() async {
-    if (_cachedRoot != null) return _cachedRoot!;
+    // if (externalPath != null) {
+    //   final external = Directory(externalPath!);
+    //   if (await external.exists()) {
+    //     try {
+    //       final testFile = File(p.join(external.path, '.storii_write_test'));
+    //       await testFile.writeAsString('');
+    //       await testFile.delete();
+    //       return external;
+    //     } catch (e) {
+    //       LogService.log(
+    //         'Failed to write to download location: $externalPath',
+    //         originalError: e,
+    //         level: .error,
+    //         source: 'DownloadsFilesystemHelper',
+    //       );
+    //     }
+    //   }
+    // }
 
     final base = await getApplicationDocumentsDirectory();
     final dir = Directory(p.join(base.path, downloadsDir));
 
     if (!await dir.exists()) await dir.create(recursive: true);
 
-    _cachedRoot = dir;
-    return _cachedRoot!;
-  }
-
-  Future<Directory> itemDirectory(String itemTitle) async {
-    final root = await rootDirectory();
-    final name = _sanitize(itemTitle);
-    final dir = Directory(p.join(root.path, name));
-    if (!await dir.exists()) await dir.create();
     return dir;
   }
 
-  Future<String> trackPath({
-    required String itemTitle,
-    required String filename,
-  }) async {
-    final dir = await itemDirectory(itemTitle);
+  Future<Directory> audiobookDirectory(String libraryItemId) async {
+    final root = await rootDirectory();
+    final dir = Directory(p.join(root.path, audiobooksSubDir, libraryItemId));
+    if (!await dir.exists()) await dir.create(recursive: true);
+    return dir;
+  }
+
+  Future<String> audiobookTrackPath(
+    String libraryItemId,
+    String filename,
+  ) async {
+    final dir = await audiobookDirectory(libraryItemId);
     return p.join(dir.path, filename);
   }
 
-  Future<String?> trackPathIfExists({
-    required String itemTitle,
-    required String filename,
-  }) async {
-    final path = await trackPath(itemTitle: itemTitle, filename: filename);
+  Future<String?> audiobookTrackPathIfExists(
+    String libraryItemId,
+    String filename,
+  ) async {
+    final path = await audiobookTrackPath(libraryItemId, filename);
     final fileExists = await fileIntact(path);
     return fileExists ? path : null;
   }
 
-  Future<String> coverPath(String itemTitle) async {
-    final dir = await itemDirectory(itemTitle);
-    return p.join(dir.path, 'cover.jpg');
+  Future<String> audiobookCoverPath(String libraryItemId) async {
+    final dir = await audiobookDirectory(libraryItemId);
+    return p.join(dir.path, coverName);
   }
 
-  Future<void> saveCover(String itemTitle, Uint8List data) async {
-    final path = await coverPath(itemTitle);
+  Future<String?> audiobookCoverPathIfExists(String libraryItemId) async {
+    final path = await audiobookCoverPath(libraryItemId);
+    final fileExists = await fileIntact(path);
+    return fileExists ? path : null;
+  }
+
+  Future<void> saveAudiobookCover(String libraryItemId, List<int> data) async {
+    final path = await audiobookCoverPath(libraryItemId);
     await File(path).writeAsBytes(data);
   }
 
-  Future<String?> coverPathIfExists(String itemTitle) async {
-    final path = await coverPath(itemTitle);
+  Future<void> deleteAudiobook(String libraryItemId) async {
+    final root = await rootDirectory();
+    final dir = Directory(p.join(root.path, audiobooksSubDir, libraryItemId));
+    if (await dir.exists()) await dir.delete(recursive: true);
+  }
+
+  Future<Directory> podcastDirectory(String libraryItemId) async {
+    final root = await rootDirectory();
+    final dir = Directory(p.join(root.path, podcastsSubDir, libraryItemId));
+    if (!await dir.exists()) await dir.create(recursive: true);
+    return dir;
+  }
+
+  Future<Directory> episodeDirectory(
+    String libraryItemId,
+    String episodeId,
+  ) async {
+    final root = await rootDirectory();
+    final dir = Directory(
+      p.join(root.path, podcastsSubDir, libraryItemId, episodeId),
+    );
+    if (!await dir.exists()) await dir.create(recursive: true);
+    return dir;
+  }
+
+  Future<String> podcastTrackPath(
+    String libraryItemId,
+    String episodeId,
+    String filename,
+  ) async {
+    final dir = await episodeDirectory(libraryItemId, episodeId);
+    return p.join(dir.path, filename);
+  }
+
+  Future<String?> podcastTrackPathIfExists(
+    String libraryItemId,
+    String episodeId,
+    String filename,
+  ) async {
+    final path = await podcastTrackPath(libraryItemId, episodeId, filename);
     final fileExists = await fileIntact(path);
     return fileExists ? path : null;
   }
 
-  Future<bool> fileIntact(String path) async {
+  Future<String> podcastCoverPath(String libraryItemId) async {
+    final dir = await podcastDirectory(libraryItemId);
+    return p.join(dir.path, coverName);
+  }
+
+  Future<String?> podcastCoverPathIfExists(String libraryItemId) async {
+    final path = await podcastCoverPath(libraryItemId);
+    final fileExists = await fileIntact(path);
+    return fileExists ? path : null;
+  }
+
+  Future<void> savePodcastCover(String libraryItemId, List<int> data) async {
+    final path = await podcastCoverPath(libraryItemId);
+    await File(path).writeAsBytes(data);
+  }
+
+  Future<void> deletePodcastEpisode(
+    String libraryItemId,
+    String episodeId,
+  ) async {
+    final root = await rootDirectory();
+    final dir = Directory(
+      p.join(root.path, podcastsSubDir, libraryItemId, episodeId),
+    );
+    if (await dir.exists()) await dir.delete(recursive: true);
+  }
+
+  Future<void> deletePodcastIfEmpty(String libraryItemId) async {
+    final root = await rootDirectory();
+    final dir = Directory(p.join(root.path, podcastsSubDir, libraryItemId));
+    if (await dir.exists()) {
+      final entities = dir.listSync();
+      if (entities.isEmpty) {
+        await dir.delete(recursive: true);
+      }
+    }
+  }
+
+  Future<bool> fileIntact(String path, {int expectedBytes = 0}) async {
     final f = File(path);
-    return await f.exists() && await f.length() > 0;
+    if (!await f.exists()) return false;
+    final actual = await f.length();
+    if (actual <= 0) return false;
+    return expectedBytes <= 0 || actual >= expectedBytes;
   }
 
   Future<int> fileSize(String path) async {
@@ -82,15 +180,12 @@ class DownloadsFilesystemHelper {
     return await f.length();
   }
 
-  Future<void> deleteItem(String itemTitle) async {
-    final dir = await itemDirectory(itemTitle);
-    await dir.delete(recursive: true);
-  }
-
   Future<bool> isFullyDownloaded(DownloadItem item) async {
     if (item.tracks.isEmpty) return false;
     final results = await Future.wait(
-      item.tracks.map((t) => fileIntact(t.localPath)),
+      item.tracks.map(
+        (t) => fileIntact(t.localPath, expectedBytes: t.bytesTotal),
+      ),
     );
     return results.every((intact) => intact);
   }
@@ -106,20 +201,38 @@ class DownloadsFilesystemHelper {
     return f.openWrite(mode: FileMode.append);
   }
 
-  Future<void> truncate(String path) async {
-    final f = File(path);
-    await f.writeAsBytes([]);
-  }
-
   Future<bool> exists(String path) async {
     return await File(path).exists();
   }
 
-  String _sanitize(String name) {
-    final cleaned = name.replaceAll(RegExp(r'[<>:"/\\|?*]'), '_').trim();
+  Future<(Map<int, String>, String?)> resolveLocalPaths(
+    PlaybackSession session,
+  ) async {
+    final tracks = session.audioTracks;
+    final trackPaths = <int, String>{};
+    if (tracks == null || tracks.isEmpty) return (trackPaths, null);
 
-    return cleaned.length > _maxNameLength
-        ? cleaned.substring(0, _maxNameLength)
-        : cleaned;
+    final String? coverPath;
+    if (session.episodeId != null) {
+      coverPath = await podcastCoverPathIfExists(session.libraryItemId);
+      final track = tracks.first;
+      final local = await podcastTrackPathIfExists(
+        session.libraryItemId,
+        session.episodeId!,
+        track.metadata?.filename ?? session.episodeId!,
+      );
+      if (local != null) trackPaths[track.index] = local;
+    } else {
+      coverPath = await audiobookCoverPathIfExists(session.libraryItemId);
+      for (final track in tracks) {
+        final local = await audiobookTrackPathIfExists(
+          session.libraryItemId,
+          track.metadata?.filename ?? track.index.toString(),
+        );
+        if (local != null) trackPaths[track.index] = local;
+      }
+    }
+
+    return (trackPaths, coverPath);
   }
 }

--- a/lib/features/downloads/logic/downloads_filesystem_helper.g.dart
+++ b/lib/features/downloads/logic/downloads_filesystem_helper.g.dart
@@ -54,4 +54,4 @@ final class DownloadsFsHelperProvider
   }
 }
 
-String _$downloadsFsHelperHash() => r'f1087d43dfccea21f1f0ff337b03186842d73ba7';
+String _$downloadsFsHelperHash() => r'be3163f315f866a680010f26ce385ac3a692a79c';

--- a/lib/features/downloads/models/download_item.dart
+++ b/lib/features/downloads/models/download_item.dart
@@ -8,6 +8,8 @@ part 'download_item.g.dart';
 
 enum DownloadStatus { queued, downloading, completed, failed, paused }
 
+enum DownloadMediaType { audiobook, podcast }
+
 @freezed
 sealed class DownloadTrack with _$DownloadTrack {
   const DownloadTrack._();
@@ -36,6 +38,7 @@ sealed class DownloadItem with _$DownloadItem {
     required String title,
     required String author,
     required List<DownloadTrack> tracks,
+    @Default(DownloadMediaType.audiobook) DownloadMediaType mediaType,
     @Default(DownloadStatus.queued) DownloadStatus status,
     DateTime? startedAt,
     String? episodeId,

--- a/lib/features/downloads/models/download_item.freezed.dart
+++ b/lib/features/downloads/models/download_item.freezed.dart
@@ -305,7 +305,7 @@ $AudioTrackCopyWith<$Res> get audioTrack {
 /// @nodoc
 mixin _$DownloadItem {
 
- Uri get serverUrl; String get libraryItemId; String get userId; String get title; String get author; List<DownloadTrack> get tracks; DownloadStatus get status; DateTime? get startedAt; String? get episodeId;
+ Uri get serverUrl; String get libraryItemId; String get userId; String get title; String get author; List<DownloadTrack> get tracks; DownloadMediaType get mediaType; DownloadStatus get status; DateTime? get startedAt; String? get episodeId;
 /// Create a copy of DownloadItem
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -318,16 +318,16 @@ $DownloadItemCopyWith<DownloadItem> get copyWith => _$DownloadItemCopyWithImpl<D
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is DownloadItem&&(identical(other.serverUrl, serverUrl) || other.serverUrl == serverUrl)&&(identical(other.libraryItemId, libraryItemId) || other.libraryItemId == libraryItemId)&&(identical(other.userId, userId) || other.userId == userId)&&(identical(other.title, title) || other.title == title)&&(identical(other.author, author) || other.author == author)&&const DeepCollectionEquality().equals(other.tracks, tracks)&&(identical(other.status, status) || other.status == status)&&(identical(other.startedAt, startedAt) || other.startedAt == startedAt)&&(identical(other.episodeId, episodeId) || other.episodeId == episodeId));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is DownloadItem&&(identical(other.serverUrl, serverUrl) || other.serverUrl == serverUrl)&&(identical(other.libraryItemId, libraryItemId) || other.libraryItemId == libraryItemId)&&(identical(other.userId, userId) || other.userId == userId)&&(identical(other.title, title) || other.title == title)&&(identical(other.author, author) || other.author == author)&&const DeepCollectionEquality().equals(other.tracks, tracks)&&(identical(other.mediaType, mediaType) || other.mediaType == mediaType)&&(identical(other.status, status) || other.status == status)&&(identical(other.startedAt, startedAt) || other.startedAt == startedAt)&&(identical(other.episodeId, episodeId) || other.episodeId == episodeId));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,serverUrl,libraryItemId,userId,title,author,const DeepCollectionEquality().hash(tracks),status,startedAt,episodeId);
+int get hashCode => Object.hash(runtimeType,serverUrl,libraryItemId,userId,title,author,const DeepCollectionEquality().hash(tracks),mediaType,status,startedAt,episodeId);
 
 @override
 String toString() {
-  return 'DownloadItem(serverUrl: $serverUrl, libraryItemId: $libraryItemId, userId: $userId, title: $title, author: $author, tracks: $tracks, status: $status, startedAt: $startedAt, episodeId: $episodeId)';
+  return 'DownloadItem(serverUrl: $serverUrl, libraryItemId: $libraryItemId, userId: $userId, title: $title, author: $author, tracks: $tracks, mediaType: $mediaType, status: $status, startedAt: $startedAt, episodeId: $episodeId)';
 }
 
 
@@ -338,7 +338,7 @@ abstract mixin class $DownloadItemCopyWith<$Res>  {
   factory $DownloadItemCopyWith(DownloadItem value, $Res Function(DownloadItem) _then) = _$DownloadItemCopyWithImpl;
 @useResult
 $Res call({
- Uri serverUrl, String libraryItemId, String userId, String title, String author, List<DownloadTrack> tracks, DownloadStatus status, DateTime? startedAt, String? episodeId
+ Uri serverUrl, String libraryItemId, String userId, String title, String author, List<DownloadTrack> tracks, DownloadMediaType mediaType, DownloadStatus status, DateTime? startedAt, String? episodeId
 });
 
 
@@ -355,7 +355,7 @@ class _$DownloadItemCopyWithImpl<$Res>
 
 /// Create a copy of DownloadItem
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? serverUrl = null,Object? libraryItemId = null,Object? userId = null,Object? title = null,Object? author = null,Object? tracks = null,Object? status = null,Object? startedAt = freezed,Object? episodeId = freezed,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? serverUrl = null,Object? libraryItemId = null,Object? userId = null,Object? title = null,Object? author = null,Object? tracks = null,Object? mediaType = null,Object? status = null,Object? startedAt = freezed,Object? episodeId = freezed,}) {
   return _then(_self.copyWith(
 serverUrl: null == serverUrl ? _self.serverUrl : serverUrl // ignore: cast_nullable_to_non_nullable
 as Uri,libraryItemId: null == libraryItemId ? _self.libraryItemId : libraryItemId // ignore: cast_nullable_to_non_nullable
@@ -363,7 +363,8 @@ as String,userId: null == userId ? _self.userId : userId // ignore: cast_nullabl
 as String,title: null == title ? _self.title : title // ignore: cast_nullable_to_non_nullable
 as String,author: null == author ? _self.author : author // ignore: cast_nullable_to_non_nullable
 as String,tracks: null == tracks ? _self.tracks : tracks // ignore: cast_nullable_to_non_nullable
-as List<DownloadTrack>,status: null == status ? _self.status : status // ignore: cast_nullable_to_non_nullable
+as List<DownloadTrack>,mediaType: null == mediaType ? _self.mediaType : mediaType // ignore: cast_nullable_to_non_nullable
+as DownloadMediaType,status: null == status ? _self.status : status // ignore: cast_nullable_to_non_nullable
 as DownloadStatus,startedAt: freezed == startedAt ? _self.startedAt : startedAt // ignore: cast_nullable_to_non_nullable
 as DateTime?,episodeId: freezed == episodeId ? _self.episodeId : episodeId // ignore: cast_nullable_to_non_nullable
 as String?,
@@ -448,10 +449,10 @@ return $default(_that);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( Uri serverUrl,  String libraryItemId,  String userId,  String title,  String author,  List<DownloadTrack> tracks,  DownloadStatus status,  DateTime? startedAt,  String? episodeId)?  $default,{required TResult orElse(),}) {final _that = this;
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( Uri serverUrl,  String libraryItemId,  String userId,  String title,  String author,  List<DownloadTrack> tracks,  DownloadMediaType mediaType,  DownloadStatus status,  DateTime? startedAt,  String? episodeId)?  $default,{required TResult orElse(),}) {final _that = this;
 switch (_that) {
 case _DownloadItem() when $default != null:
-return $default(_that.serverUrl,_that.libraryItemId,_that.userId,_that.title,_that.author,_that.tracks,_that.status,_that.startedAt,_that.episodeId);case _:
+return $default(_that.serverUrl,_that.libraryItemId,_that.userId,_that.title,_that.author,_that.tracks,_that.mediaType,_that.status,_that.startedAt,_that.episodeId);case _:
   return orElse();
 
 }
@@ -469,10 +470,10 @@ return $default(_that.serverUrl,_that.libraryItemId,_that.userId,_that.title,_th
 /// }
 /// ```
 
-@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( Uri serverUrl,  String libraryItemId,  String userId,  String title,  String author,  List<DownloadTrack> tracks,  DownloadStatus status,  DateTime? startedAt,  String? episodeId)  $default,) {final _that = this;
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( Uri serverUrl,  String libraryItemId,  String userId,  String title,  String author,  List<DownloadTrack> tracks,  DownloadMediaType mediaType,  DownloadStatus status,  DateTime? startedAt,  String? episodeId)  $default,) {final _that = this;
 switch (_that) {
 case _DownloadItem():
-return $default(_that.serverUrl,_that.libraryItemId,_that.userId,_that.title,_that.author,_that.tracks,_that.status,_that.startedAt,_that.episodeId);}
+return $default(_that.serverUrl,_that.libraryItemId,_that.userId,_that.title,_that.author,_that.tracks,_that.mediaType,_that.status,_that.startedAt,_that.episodeId);}
 }
 /// A variant of `when` that fallback to returning `null`
 ///
@@ -486,10 +487,10 @@ return $default(_that.serverUrl,_that.libraryItemId,_that.userId,_that.title,_th
 /// }
 /// ```
 
-@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( Uri serverUrl,  String libraryItemId,  String userId,  String title,  String author,  List<DownloadTrack> tracks,  DownloadStatus status,  DateTime? startedAt,  String? episodeId)?  $default,) {final _that = this;
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( Uri serverUrl,  String libraryItemId,  String userId,  String title,  String author,  List<DownloadTrack> tracks,  DownloadMediaType mediaType,  DownloadStatus status,  DateTime? startedAt,  String? episodeId)?  $default,) {final _that = this;
 switch (_that) {
 case _DownloadItem() when $default != null:
-return $default(_that.serverUrl,_that.libraryItemId,_that.userId,_that.title,_that.author,_that.tracks,_that.status,_that.startedAt,_that.episodeId);case _:
+return $default(_that.serverUrl,_that.libraryItemId,_that.userId,_that.title,_that.author,_that.tracks,_that.mediaType,_that.status,_that.startedAt,_that.episodeId);case _:
   return null;
 
 }
@@ -501,7 +502,7 @@ return $default(_that.serverUrl,_that.libraryItemId,_that.userId,_that.title,_th
 @JsonSerializable()
 
 class _DownloadItem extends DownloadItem {
-  const _DownloadItem({required this.serverUrl, required this.libraryItemId, required this.userId, required this.title, required this.author, required final  List<DownloadTrack> tracks, this.status = DownloadStatus.queued, this.startedAt, this.episodeId}): _tracks = tracks,super._();
+  const _DownloadItem({required this.serverUrl, required this.libraryItemId, required this.userId, required this.title, required this.author, required final  List<DownloadTrack> tracks, this.mediaType = DownloadMediaType.audiobook, this.status = DownloadStatus.queued, this.startedAt, this.episodeId}): _tracks = tracks,super._();
   factory _DownloadItem.fromJson(Map<String, dynamic> json) => _$DownloadItemFromJson(json);
 
 @override final  Uri serverUrl;
@@ -516,6 +517,7 @@ class _DownloadItem extends DownloadItem {
   return EqualUnmodifiableListView(_tracks);
 }
 
+@override@JsonKey() final  DownloadMediaType mediaType;
 @override@JsonKey() final  DownloadStatus status;
 @override final  DateTime? startedAt;
 @override final  String? episodeId;
@@ -533,16 +535,16 @@ Map<String, dynamic> toJson() {
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is _DownloadItem&&(identical(other.serverUrl, serverUrl) || other.serverUrl == serverUrl)&&(identical(other.libraryItemId, libraryItemId) || other.libraryItemId == libraryItemId)&&(identical(other.userId, userId) || other.userId == userId)&&(identical(other.title, title) || other.title == title)&&(identical(other.author, author) || other.author == author)&&const DeepCollectionEquality().equals(other._tracks, _tracks)&&(identical(other.status, status) || other.status == status)&&(identical(other.startedAt, startedAt) || other.startedAt == startedAt)&&(identical(other.episodeId, episodeId) || other.episodeId == episodeId));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _DownloadItem&&(identical(other.serverUrl, serverUrl) || other.serverUrl == serverUrl)&&(identical(other.libraryItemId, libraryItemId) || other.libraryItemId == libraryItemId)&&(identical(other.userId, userId) || other.userId == userId)&&(identical(other.title, title) || other.title == title)&&(identical(other.author, author) || other.author == author)&&const DeepCollectionEquality().equals(other._tracks, _tracks)&&(identical(other.mediaType, mediaType) || other.mediaType == mediaType)&&(identical(other.status, status) || other.status == status)&&(identical(other.startedAt, startedAt) || other.startedAt == startedAt)&&(identical(other.episodeId, episodeId) || other.episodeId == episodeId));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,serverUrl,libraryItemId,userId,title,author,const DeepCollectionEquality().hash(_tracks),status,startedAt,episodeId);
+int get hashCode => Object.hash(runtimeType,serverUrl,libraryItemId,userId,title,author,const DeepCollectionEquality().hash(_tracks),mediaType,status,startedAt,episodeId);
 
 @override
 String toString() {
-  return 'DownloadItem(serverUrl: $serverUrl, libraryItemId: $libraryItemId, userId: $userId, title: $title, author: $author, tracks: $tracks, status: $status, startedAt: $startedAt, episodeId: $episodeId)';
+  return 'DownloadItem(serverUrl: $serverUrl, libraryItemId: $libraryItemId, userId: $userId, title: $title, author: $author, tracks: $tracks, mediaType: $mediaType, status: $status, startedAt: $startedAt, episodeId: $episodeId)';
 }
 
 
@@ -553,7 +555,7 @@ abstract mixin class _$DownloadItemCopyWith<$Res> implements $DownloadItemCopyWi
   factory _$DownloadItemCopyWith(_DownloadItem value, $Res Function(_DownloadItem) _then) = __$DownloadItemCopyWithImpl;
 @override @useResult
 $Res call({
- Uri serverUrl, String libraryItemId, String userId, String title, String author, List<DownloadTrack> tracks, DownloadStatus status, DateTime? startedAt, String? episodeId
+ Uri serverUrl, String libraryItemId, String userId, String title, String author, List<DownloadTrack> tracks, DownloadMediaType mediaType, DownloadStatus status, DateTime? startedAt, String? episodeId
 });
 
 
@@ -570,7 +572,7 @@ class __$DownloadItemCopyWithImpl<$Res>
 
 /// Create a copy of DownloadItem
 /// with the given fields replaced by the non-null parameter values.
-@override @pragma('vm:prefer-inline') $Res call({Object? serverUrl = null,Object? libraryItemId = null,Object? userId = null,Object? title = null,Object? author = null,Object? tracks = null,Object? status = null,Object? startedAt = freezed,Object? episodeId = freezed,}) {
+@override @pragma('vm:prefer-inline') $Res call({Object? serverUrl = null,Object? libraryItemId = null,Object? userId = null,Object? title = null,Object? author = null,Object? tracks = null,Object? mediaType = null,Object? status = null,Object? startedAt = freezed,Object? episodeId = freezed,}) {
   return _then(_DownloadItem(
 serverUrl: null == serverUrl ? _self.serverUrl : serverUrl // ignore: cast_nullable_to_non_nullable
 as Uri,libraryItemId: null == libraryItemId ? _self.libraryItemId : libraryItemId // ignore: cast_nullable_to_non_nullable
@@ -578,7 +580,8 @@ as String,userId: null == userId ? _self.userId : userId // ignore: cast_nullabl
 as String,title: null == title ? _self.title : title // ignore: cast_nullable_to_non_nullable
 as String,author: null == author ? _self.author : author // ignore: cast_nullable_to_non_nullable
 as String,tracks: null == tracks ? _self._tracks : tracks // ignore: cast_nullable_to_non_nullable
-as List<DownloadTrack>,status: null == status ? _self.status : status // ignore: cast_nullable_to_non_nullable
+as List<DownloadTrack>,mediaType: null == mediaType ? _self.mediaType : mediaType // ignore: cast_nullable_to_non_nullable
+as DownloadMediaType,status: null == status ? _self.status : status // ignore: cast_nullable_to_non_nullable
 as DownloadStatus,startedAt: freezed == startedAt ? _self.startedAt : startedAt // ignore: cast_nullable_to_non_nullable
 as DateTime?,episodeId: freezed == episodeId ? _self.episodeId : episodeId // ignore: cast_nullable_to_non_nullable
 as String?,

--- a/lib/features/downloads/models/download_item.g.dart
+++ b/lib/features/downloads/models/download_item.g.dart
@@ -48,6 +48,9 @@ _DownloadItem _$DownloadItemFromJson(Map<String, dynamic> json) =>
       tracks: (json['tracks'] as List<dynamic>)
           .map((e) => DownloadTrack.fromJson(e as Map<String, dynamic>))
           .toList(),
+      mediaType:
+          $enumDecodeNullable(_$DownloadMediaTypeEnumMap, json['mediaType']) ??
+          DownloadMediaType.audiobook,
       status:
           $enumDecodeNullable(_$DownloadStatusEnumMap, json['status']) ??
           DownloadStatus.queued,
@@ -65,7 +68,13 @@ Map<String, dynamic> _$DownloadItemToJson(_DownloadItem instance) =>
       'title': instance.title,
       'author': instance.author,
       'tracks': instance.tracks.map((e) => e.toJson()).toList(),
+      'mediaType': _$DownloadMediaTypeEnumMap[instance.mediaType]!,
       'status': _$DownloadStatusEnumMap[instance.status]!,
       'startedAt': ?instance.startedAt?.toIso8601String(),
       'episodeId': ?instance.episodeId,
     };
+
+const _$DownloadMediaTypeEnumMap = {
+  DownloadMediaType.audiobook: 'audiobook',
+  DownloadMediaType.podcast: 'podcast',
+};

--- a/lib/features/home/logic/shelves_provider.dart
+++ b/lib/features/home/logic/shelves_provider.dart
@@ -1,10 +1,14 @@
 import 'package:abs_api/abs_api.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
+import 'package:storii/app/init.dart';
 import 'package:storii/app/providers/api_providers.dart';
 import 'package:storii/app/providers/authenticated_user_provider.dart';
+import 'package:storii/app/providers/connection_providers.dart';
 import 'package:storii/app/providers/media_progress_map_provider.dart';
+import 'package:storii/features/downloads/logic/downloads_provider.dart';
 import 'package:storii/features/library/logic/active_library_provider.dart';
 import 'package:storii/shared/helpers/ref_extensions.dart';
+import 'package:storii/storage/local/items_cache.dart';
 
 part 'shelves_provider.g.dart';
 
@@ -46,6 +50,47 @@ Future<List<Shelf>> shelves(Ref ref) async {
 
 @Riverpod(keepAlive: true)
 Future<List<Shelf>> rawShelves(Ref ref) async {
+  final isConnected = await ref.watch(socketStatusProvider.future);
+  if (!isConnected) {
+    final downloads = await ref.read(downloadsProvider.future);
+    final cache = ref.read(itemsCacheProvider.notifier);
+    final audiobooks = <LibraryItem>[];
+    final podcasts = <LibraryItem>[];
+
+    for (final d in downloads.values.where((d) => d.isComplete)) {
+      final item = cache.get(d.libraryItemId);
+      if (item != null) {
+        switch (item.mediaType) {
+          case .book:
+            audiobooks.add(item);
+          case .podcast:
+            podcasts.add(item);
+        }
+      }
+    }
+
+    return [
+      if (audiobooks.isNotEmpty)
+        Shelf.libraryItems(
+          id: 'offline_downloads',
+          label: l10n.audiobooks,
+          labelStringKey: 'downloads',
+          type: .book,
+          entities: audiobooks,
+          total: audiobooks.length,
+        ),
+      if (podcasts.isNotEmpty)
+        Shelf.libraryItems(
+          id: 'offline_downloads',
+          label: l10n.podcasts,
+          labelStringKey: 'downloads',
+          type: .podcast,
+          entities: podcasts,
+          total: podcasts.length,
+        ),
+    ];
+  }
+
   final libraryId = (await ref.watch(
     activeLibraryDetailsProvider.future,
   )).library.id;

--- a/lib/features/home/logic/shelves_provider.g.dart
+++ b/lib/features/home/logic/shelves_provider.g.dart
@@ -85,4 +85,4 @@ final class RawShelvesProvider
   }
 }
 
-String _$rawShelvesHash() => r'4a598b391d0cc0c3bd376ba10ad06580cb2547ed';
+String _$rawShelvesHash() => r'f56e4f9bda5d79185377ebd65b8d37ba4c672b3d';

--- a/lib/features/home/ui/home_screen.dart
+++ b/lib/features/home/ui/home_screen.dart
@@ -44,9 +44,16 @@ class HomeScreen extends ConsumerWidget {
               );
             }
             final displayList =
-                shelves.where((s) => s.identity != null).toList()..sort(
-                  (a, b) => a.identity!.index.compareTo(b.identity!.index),
-                );
+                shelves
+                    .where(
+                      (s) => s.identity != null || s.id == 'offline_downloads',
+                    )
+                    .toList()
+                  ..sort(
+                    (a, b) => (a.identity?.index ?? -1).compareTo(
+                      b.identity?.index ?? -1,
+                    ),
+                  );
 
             return ListView.builder(
               padding: const .symmetric(vertical: 16),

--- a/lib/features/item/logic/item_detail_provider.dart
+++ b/lib/features/item/logic/item_detail_provider.dart
@@ -4,6 +4,7 @@ import 'package:abs_api/abs_api.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 import 'package:storii/app/providers/api_providers.dart';
 import 'package:storii/app/providers/authenticated_user_provider.dart';
+import 'package:storii/app/providers/connection_providers.dart';
 import 'package:storii/shared/helpers/app_error.dart';
 import 'package:storii/shared/helpers/ref_extensions.dart';
 import 'package:storii/storage/local/items_cache.dart';
@@ -13,6 +14,14 @@ part 'item_detail_provider.g.dart';
 @Riverpod(keepAlive: true)
 Future<LibraryItem> itemDetail(Ref ref, String id) async {
   final cache = ref.read(itemsCacheProvider.notifier);
+
+  final isConnected = await ref.watch(socketStatusProvider.future);
+  if (!isConnected) {
+    final localItem = cache.get(id);
+    if (localItem != null) return localItem;
+    throw StateError('No internet and item not in cache');
+  }
+
   final user = await ref.watch(authenticatedUserProvider.future);
   final api = ref.read(itemApiProvider(user));
 

--- a/lib/features/item/logic/item_detail_provider.dart
+++ b/lib/features/item/logic/item_detail_provider.dart
@@ -1,11 +1,9 @@
+import 'dart:async';
+
 import 'package:abs_api/abs_api.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
-import 'package:storii/app/logs/log_service.dart';
 import 'package:storii/app/providers/api_providers.dart';
 import 'package:storii/app/providers/authenticated_user_provider.dart';
-import 'package:storii/app/providers/settings_provider.dart';
-import 'package:storii/features/downloads/logic/downloads_provider.dart';
-import 'package:storii/shared/helpers/abs_model_extensions.dart';
 import 'package:storii/shared/helpers/app_error.dart';
 import 'package:storii/shared/helpers/ref_extensions.dart';
 import 'package:storii/storage/local/items_cache.dart';
@@ -14,49 +12,23 @@ part 'item_detail_provider.g.dart';
 
 @Riverpod(keepAlive: true)
 Future<LibraryItem> itemDetail(Ref ref, String id) async {
-  final downloads = await ref.read(downloadsProvider.future);
-  final download = downloads[id];
-
-  if (download != null && download.isComplete) {
-    final cache = ref.read(itemsCacheProvider.notifier);
-    final localItem = cache.get(id);
-    final serverUrl = ref.read(serverUrlProvider);
-    if (download.serverUrl != serverUrl) {
-      if (localItem == null) {
-        throw StateError(
-          'old download from different server. item details not saved',
-        );
-      }
-      return localItem;
-    }
-
-    try {
-      final user = await ref.read(authenticatedUserProvider.future);
-      final remoteItem = await ref
-          .read(itemApiProvider(user))
-          .get(id, includeProgress: true);
-
-      await cache.put(remoteItem);
-      return remoteItem;
-    } on AppError catch (error) {
-      LogService.log(
-        'Failed to refresh ${localItem?.title}: ${error.message}',
-        source: 'itemDetail',
-        level: .warning,
-        originalError: error.originalError,
-        stackTrace: error.stackTrace,
-      );
-    }
-    if (localItem != null) {
-      return localItem;
-    }
-  }
-
+  final cache = ref.read(itemsCacheProvider.notifier);
   final user = await ref.watch(authenticatedUserProvider.future);
   final api = ref.read(itemApiProvider(user));
-  return ref.logApiCall(
-    () => api.get(id, includeProgress: true),
-    source: 'itemDetail',
-    logMessage: 'Error fetching library item details',
-  );
+
+  try {
+    final remoteItem = await ref.logApiCall(
+      () => api.get(id, includeProgress: true),
+      source: 'itemDetail',
+      logMessage: 'Error fetching library item details',
+    );
+    unawaited(cache.put(remoteItem));
+    return remoteItem;
+  } on AppError catch (error) {
+    if (error.type == .network || error.type == .timeout) {
+      final localItem = cache.get(id);
+      if (localItem != null) return localItem;
+    }
+    rethrow;
+  }
 }

--- a/lib/features/item/logic/item_detail_provider.g.dart
+++ b/lib/features/item/logic/item_detail_provider.g.dart
@@ -64,7 +64,7 @@ final class ItemDetailProvider
   }
 }
 
-String _$itemDetailHash() => r'c0d06936b76cc32c6e1136010d95fc012be478ba';
+String _$itemDetailHash() => r'd107d34415091c8a4a700f2005af11b6c88c0613';
 
 final class ItemDetailFamily extends $Family
     with $FunctionalFamilyOverride<FutureOr<LibraryItem>, String> {

--- a/lib/features/item/logic/item_detail_provider.g.dart
+++ b/lib/features/item/logic/item_detail_provider.g.dart
@@ -64,7 +64,7 @@ final class ItemDetailProvider
   }
 }
 
-String _$itemDetailHash() => r'd107d34415091c8a4a700f2005af11b6c88c0613';
+String _$itemDetailHash() => r'2a44a0f1e84357fdcdf662e2b34860bc090621b2';
 
 final class ItemDetailFamily extends $Family
     with $FunctionalFamilyOverride<FutureOr<LibraryItem>, String> {

--- a/lib/features/item/ui/current_session_tile.dart
+++ b/lib/features/item/ui/current_session_tile.dart
@@ -1,0 +1,79 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:storii/app/config/constants.dart';
+import 'package:storii/app/init.dart';
+import 'package:storii/features/player/logic/session_notifier.dart';
+import 'package:storii/shared/helpers/extensions.dart';
+import 'package:storii/shared/widgets/app_dialog.dart';
+import 'package:storii/storage/local/session_store.dart';
+
+class CurrentSessionTile extends ConsumerWidget {
+  const CurrentSessionTile({super.key, required this.itemId});
+
+  final String itemId;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final scheme = Theme.of(context).colorScheme;
+
+    final sessionAsync = ref.watch(localSessionProvider(itemId));
+    return sessionAsync.when(
+      loading: () => const SizedBox.shrink(),
+      error: (error, stack) => const SizedBox.shrink(),
+      data: (session) {
+        final isLocal = session != null && session.playMethod == .local;
+
+        if (isLocal) {
+          return Stack(
+            children: [
+              Padding(
+                padding: const .all(16),
+                child: Container(
+                  padding: const .all(16),
+                  decoration: BoxDecoration(
+                    color: scheme.surfaceContainerHighest,
+                    border: .all(width: 2, color: scheme.outlineVariant),
+                    borderRadius: .circular(kRadius),
+                  ),
+                  child: Center(
+                    child: Text(
+                      l10n.localSession(
+                        session.currentTime.toReadableDuration(),
+                      ),
+                      style: TextStyle(color: scheme.onSurfaceVariant),
+                    ),
+                  ),
+                ),
+              ),
+              Align(
+                alignment: .centerRight,
+                child: IconButton(
+                  onPressed: () {
+                    AppDialog.show(
+                      context,
+                      title: l10n.localSessionDeleteQ,
+                      actionLabel: l10n.delete,
+                      body: Text(l10n.localSessionDeleteBody),
+                      onTap: () async {
+                        await ref
+                            .read(sessionStoreProvider.notifier)
+                            .delete(session.id);
+                      },
+                      unawaitedOnTap: true,
+                      isDestructive: true,
+                    );
+                  },
+                  icon: const Icon(Icons.cancel),
+                  visualDensity: .compact,
+                  tooltip: l10n.delete,
+                ),
+              ),
+            ],
+          );
+        }
+
+        return const SizedBox.shrink();
+      },
+    );
+  }
+}

--- a/lib/features/item/ui/current_session_tile.dart
+++ b/lib/features/item/ui/current_session_tile.dart
@@ -8,15 +8,16 @@ import 'package:storii/shared/widgets/app_dialog.dart';
 import 'package:storii/storage/local/session_store.dart';
 
 class CurrentSessionTile extends ConsumerWidget {
-  const CurrentSessionTile({super.key, required this.itemId});
+  const CurrentSessionTile({super.key, required this.itemId, this.episodeId});
 
   final String itemId;
+  final String? episodeId;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final scheme = Theme.of(context).colorScheme;
 
-    final sessionAsync = ref.watch(localSessionProvider(itemId));
+    final sessionAsync = ref.watch(localSessionProvider(itemId, episodeId));
     return sessionAsync.when(
       loading: () => const SizedBox.shrink(),
       error: (error, stack) => const SizedBox.shrink(),

--- a/lib/features/item/ui/episode_action_buttons.dart
+++ b/lib/features/item/ui/episode_action_buttons.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:storii/app/init.dart';
 import 'package:storii/app/providers/media_progress_map_provider.dart';
+import 'package:storii/features/downloads/ui/download_button.dart';
 import 'package:storii/features/item/logic/progress_notifier.dart';
 import 'package:storii/features/player/ui/history_button.dart';
 import 'package:storii/shared/widgets/app_bottom_sheet.dart';
@@ -22,10 +23,10 @@ class EpisodeActionButtons extends ConsumerWidget {
     return Row(
       mainAxisAlignment: .spaceEvenly,
       children: [
-        // DownloadButton(
-        //   libraryItemId: episode.libraryItemId,
-        //   episodeId: episode.id,
-        // ),
+        DownloadButton(
+          libraryItemId: episode.libraryItemId,
+          episodeId: episode.id,
+        ),
         HistoryButton(itemId: episode.libraryItemId, episodeId: episode.id),
         if (progress?.isFinished != true)
           IconButton(

--- a/lib/features/item/ui/episode_tile.dart
+++ b/lib/features/item/ui/episode_tile.dart
@@ -6,6 +6,7 @@ import 'package:storii/app/config/theme.dart';
 import 'package:storii/app/init.dart';
 import 'package:storii/app/providers/media_progress_map_provider.dart';
 import 'package:storii/app/providers/settings_provider.dart';
+import 'package:storii/features/item/ui/current_session_tile.dart';
 import 'package:storii/features/item/ui/episode_action_buttons.dart';
 import 'package:storii/features/item/ui/episode_metadata_sheet.dart';
 import 'package:storii/features/player/logic/audio_providers.dart';
@@ -106,7 +107,10 @@ class EpisodeTile extends ConsumerWidget {
                   ),
                   const SizedBox(height: 4),
                   _EpisodeMetaRow(episode: episode, progressPct: progressPct),
-                  const SizedBox(height: 4),
+                  CurrentSessionTile(
+                    itemId: episode.libraryItemId,
+                    episodeId: episode.id,
+                  ),
                   EpisodeActionButtons(episode: episode),
                 ],
               ),

--- a/lib/features/item/ui/item_detail_screen.dart
+++ b/lib/features/item/ui/item_detail_screen.dart
@@ -9,6 +9,7 @@ import 'package:storii/features/item/ui/action_buttons.dart';
 import 'package:storii/features/item/ui/audio_tracks_sheet.dart';
 import 'package:storii/features/item/ui/chapter_list.dart';
 import 'package:storii/features/item/ui/cover_image_title.dart';
+import 'package:storii/features/item/ui/current_session_tile.dart';
 import 'package:storii/features/item/ui/description_with_chips.dart';
 import 'package:storii/features/item/ui/episode_list.dart';
 import 'package:storii/features/item/ui/metadata_wrap.dart';
@@ -58,6 +59,7 @@ class ItemDetailScreen extends ConsumerWidget {
                           const SizedBox(height: 8),
                           PlayButton(item),
                           if (item.isBook) ProgressBar(itemId: item.id),
+                          if (item.isBook) CurrentSessionTile(itemId: item.id),
                           if (item.isBook) ActionButtons(item: item),
                         ],
                       ),

--- a/lib/features/library/ui/image_widget.dart
+++ b/lib/features/library/ui/image_widget.dart
@@ -30,9 +30,13 @@ class ImageWidget extends ConsumerWidget {
     final download = ref.watch(downloadItemProvider(id));
     if (download != null) {
       return FutureBuilder<String?>(
-        future: ref
-            .read(downloadsFsHelperProvider)
-            .coverPathIfExists(download.title),
+        future: download.mediaType == .podcast
+            ? ref
+                  .read(downloadsFsHelperProvider)
+                  .podcastCoverPathIfExists(download.libraryItemId)
+            : ref
+                  .read(downloadsFsHelperProvider)
+                  .audiobookCoverPathIfExists(download.libraryItemId),
         builder: (context, snapshot) {
           if (snapshot.hasData && snapshot.data != null) {
             return Image.file(

--- a/lib/features/player/logic/audio_providers.dart
+++ b/lib/features/player/logic/audio_providers.dart
@@ -109,10 +109,11 @@ class AudioPlayerNotifier extends _$AudioPlayerNotifier {
     );
     try {
       final download = ref.read(downloadItemProvider(itemId, episodeId));
+      final fs = ref.read(downloadsFsHelperProvider);
       final isFullyDownloaded =
           download != null &&
           download.isComplete &&
-          await DownloadsFilesystemHelper().isFullyDownloaded(download);
+          await fs.isFullyDownloaded(download);
 
       final PlaybackSession session;
       String? token;
@@ -142,7 +143,7 @@ class AudioPlayerNotifier extends _$AudioPlayerNotifier {
           ? session.chapterToTrackOffset(chapter)
           : session.getIndexAndOffset(initialPosition);
 
-      final (localPaths, coverPath) = await session.resolveLocalPaths();
+      final (localPaths, coverPath) = await fs.resolveLocalPaths(session);
       final localCount = localPaths.length;
       final totalTracks = session.audioTracks?.length ?? 0;
       if (localCount > 0) {

--- a/lib/features/player/logic/audio_providers.g.dart
+++ b/lib/features/player/logic/audio_providers.g.dart
@@ -392,7 +392,7 @@ final class AudioPlayerNotifierProvider
 }
 
 String _$audioPlayerNotifierHash() =>
-    r'050e58fbb4e7d0ef22d64fdb2c60ac0102962522';
+    r'6f0f8284149822e9e68f85a24fb9a9bcfe78bf82';
 
 abstract class _$AudioPlayerNotifier extends $Notifier<AudioPlayerState> {
   AudioPlayerState build();

--- a/lib/features/player/logic/session_extensions.dart
+++ b/lib/features/player/logic/session_extensions.dart
@@ -3,7 +3,6 @@ import 'package:audio_service/audio_service.dart';
 import 'package:storii/app/config/constants.dart';
 import 'package:storii/app/init.dart';
 import 'package:storii/app/models/chapter.dart';
-import 'package:storii/features/downloads/logic/downloads_filesystem_helper.dart';
 import 'package:storii/features/player/models/app_audio_source.dart';
 import 'package:storii/shared/helpers/abs_model_extensions.dart';
 import 'package:storii/shared/helpers/audio_mime_helper.dart';
@@ -113,34 +112,6 @@ extension PlaybackSessionX on PlaybackSession {
       sources.add(source);
     }
     return sources;
-  }
-
-  Future<(Map<int, String>, String?)> resolveLocalPaths() async {
-    final tracks = audioTracks;
-    final trackPaths = <int, String>{};
-    if (tracks == null || tracks.isEmpty) return (trackPaths, null);
-
-    final coverPath = await DownloadsFilesystemHelper().coverPathIfExists(
-      episodeId != null ? libraryItemId : displayTitle ?? libraryItemId,
-    );
-    if (episodeId != null) {
-      final local = await DownloadsFilesystemHelper().trackPathIfExists(
-        filename: tracks.first.metadata?.filename ?? episodeId!,
-        itemTitle: libraryItem?.title ?? mediaMetadata.title ?? libraryItemId,
-      );
-      if (local != null) trackPaths[1] = local;
-    } else {
-      for (final track in tracks) {
-        final local = await DownloadsFilesystemHelper().trackPathIfExists(
-          filename: track.metadata?.filename ?? track.index.toString(),
-          itemTitle: libraryItem?.title ?? libraryItemId,
-        );
-
-        if (local != null) trackPaths[track.index] = local;
-      }
-    }
-
-    return (trackPaths, coverPath);
   }
 
   (int, Duration) getIndexAndOffset([Duration? position]) {

--- a/lib/features/player/logic/session_notifier.dart
+++ b/lib/features/player/logic/session_notifier.dart
@@ -59,6 +59,19 @@ class SessionNotifier extends _$SessionNotifier {
     String? episodeId,
     required bool isSameUser,
   }) async {
+    final existing = ref
+        .read(sessionStoreProvider.notifier)
+        .getSession(item.id, episodeId);
+    if (existing != null && existing.playMethod == .local) {
+      state = existing;
+      LogService.log(
+        'local session resumed for ${existing.displayTitle}',
+        source: 'SessionNotifier',
+        level: .info,
+      );
+      return existing;
+    }
+
     final params = await ref.read(playRequestParamsProvider.future);
     final user = ref.read(currentUserProvider);
     var session = item.toPlaybackSession(
@@ -151,8 +164,8 @@ class SessionNotifier extends _$SessionNotifier {
           source: 'SessionNotifier',
           logMessage: 'session close failed for ${session.displayTitle}',
         );
+        await ref.read(sessionStoreProvider.notifier).delete(session.id);
       }
-      await ref.read(sessionStoreProvider.notifier).delete(session.id);
       LogService.log(
         'session closed for ${session.displayTitle}',
         source: 'SessionNotifier',
@@ -163,4 +176,14 @@ class SessionNotifier extends _$SessionNotifier {
       state = null;
     }
   }
+}
+
+@riverpod
+Stream<PlaybackSession?> localSession(
+  Ref ref,
+  String itemId, [
+  String? episodeId,
+]) async* {
+  final store = ref.watch(sessionStoreProvider.notifier);
+  yield* store.watchSession(itemId, episodeId);
 }

--- a/lib/features/player/logic/session_notifier.g.dart
+++ b/lib/features/player/logic/session_notifier.g.dart
@@ -41,7 +41,7 @@ final class SessionNotifierProvider
   }
 }
 
-String _$sessionNotifierHash() => r'1a5f4ed4727e1f5793060673f187b4147c357ca6';
+String _$sessionNotifierHash() => r'75729e68a6c30f157d2f74ae5c59c8c730e468fb';
 
 abstract class _$SessionNotifier extends $Notifier<PlaybackSession?> {
   PlaybackSession? build();
@@ -59,4 +59,80 @@ abstract class _$SessionNotifier extends $Notifier<PlaybackSession?> {
             >;
     element.handleCreate(ref, build);
   }
+}
+
+@ProviderFor(localSession)
+final localSessionProvider = LocalSessionFamily._();
+
+final class LocalSessionProvider
+    extends
+        $FunctionalProvider<
+          AsyncValue<PlaybackSession?>,
+          PlaybackSession?,
+          Stream<PlaybackSession?>
+        >
+    with $FutureModifier<PlaybackSession?>, $StreamProvider<PlaybackSession?> {
+  LocalSessionProvider._({
+    required LocalSessionFamily super.from,
+    required (String, String?) super.argument,
+  }) : super(
+         retry: null,
+         name: r'localSessionProvider',
+         isAutoDispose: true,
+         dependencies: null,
+         $allTransitiveDependencies: null,
+       );
+
+  @override
+  String debugGetCreateSourceHash() => _$localSessionHash();
+
+  @override
+  String toString() {
+    return r'localSessionProvider'
+        ''
+        '$argument';
+  }
+
+  @$internal
+  @override
+  $StreamProviderElement<PlaybackSession?> $createElement(
+    $ProviderPointer pointer,
+  ) => $StreamProviderElement(pointer);
+
+  @override
+  Stream<PlaybackSession?> create(Ref ref) {
+    final argument = this.argument as (String, String?);
+    return localSession(ref, argument.$1, argument.$2);
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return other is LocalSessionProvider && other.argument == argument;
+  }
+
+  @override
+  int get hashCode {
+    return argument.hashCode;
+  }
+}
+
+String _$localSessionHash() => r'0e7829392162f18a2251cc924ea490bd9d9837fe';
+
+final class LocalSessionFamily extends $Family
+    with
+        $FunctionalFamilyOverride<Stream<PlaybackSession?>, (String, String?)> {
+  LocalSessionFamily._()
+    : super(
+        retry: null,
+        name: r'localSessionProvider',
+        dependencies: null,
+        $allTransitiveDependencies: null,
+        isAutoDispose: true,
+      );
+
+  LocalSessionProvider call(String itemId, [String? episodeId]) =>
+      LocalSessionProvider._(argument: (itemId, episodeId), from: this);
+
+  @override
+  String toString() => r'localSessionProvider';
 }

--- a/lib/features/player/logic/session_sync_watcher.dart
+++ b/lib/features/player/logic/session_sync_watcher.dart
@@ -80,17 +80,17 @@ class SessionSyncWatcher extends _$SessionSyncWatcher {
       final wasConnected = prev?.value ?? false;
       final isConnected = next.value ?? false;
       if (!wasConnected && isConnected) {
-        await ref
-            .read(authenticatedUserProvider.future)
-            .then((_) => ref.read(sessionsCleanupProvider.notifier).cleanup())
-            .catchError(
-              (e) => LogService.log(
-                'reconnect sync skipped',
-                originalError: e,
-                level: .warning,
-                source: 'SessionSyncWatcher',
-              ),
-            );
+        try {
+          await ref.read(authenticatedUserProvider.future);
+          await ref.read(sessionsCleanupProvider.notifier).cleanup();
+        } catch (e) {
+          LogService.log(
+            'reconnect sync skipped',
+            originalError: e,
+            level: .warning,
+            source: 'SessionSyncWatcher',
+          );
+        }
       }
     });
   }

--- a/lib/features/player/logic/session_sync_watcher.g.dart
+++ b/lib/features/player/logic/session_sync_watcher.g.dart
@@ -42,7 +42,7 @@ final class SessionSyncWatcherProvider
 }
 
 String _$sessionSyncWatcherHash() =>
-    r'0c6089f4b0d1f9f882c4df9c4d99cdabe3813082';
+    r'c6566c5cc7908dd8ebeee9a9bc85e812b02fa150';
 
 abstract class _$SessionSyncWatcher extends $Notifier<void> {
   void build();

--- a/lib/features/player/logic/sessions_cleanup.dart
+++ b/lib/features/player/logic/sessions_cleanup.dart
@@ -4,7 +4,6 @@ import 'package:storii/app/logs/log_service.dart';
 import 'package:storii/app/models/user.dart';
 import 'package:storii/app/providers/api_providers.dart';
 import 'package:storii/app/providers/authenticated_user_provider.dart';
-import 'package:storii/app/providers/connection_providers.dart';
 import 'package:storii/shared/helpers/app_error.dart';
 import 'package:storii/shared/helpers/ref_extensions.dart';
 import 'package:storii/storage/local/session_store.dart';
@@ -22,16 +21,6 @@ class SessionsCleanup extends _$SessionsCleanup {
     final store = ref.read(sessionStoreProvider.notifier);
     final sessions = store.getAll();
     if (sessions.isEmpty) return;
-
-    final isConnected = await ref.read(socketStatusProvider.future);
-    if (!isConnected) {
-      LogService.log(
-        'server not connected, skipping session cleanup',
-        level: .info,
-        source: _source,
-      );
-      return;
-    }
 
     final user = await ref.read(authenticatedUserProvider.future);
     await syncLocalSessions(user, sessions);

--- a/lib/features/player/logic/sessions_cleanup.g.dart
+++ b/lib/features/player/logic/sessions_cleanup.g.dart
@@ -41,7 +41,7 @@ final class SessionsCleanupProvider
   }
 }
 
-String _$sessionsCleanupHash() => r'75e5da0a1d28415cc59b3c0cc61b1b4aeca957fd';
+String _$sessionsCleanupHash() => r'd3667b5842391e4350ef5a1b5c449bbfd6f6a7cc';
 
 abstract class _$SessionsCleanup extends $Notifier<void> {
   void build();

--- a/lib/features/player/ui/full_player.dart
+++ b/lib/features/player/ui/full_player.dart
@@ -117,6 +117,7 @@ class FullPlayer extends ConsumerWidget {
                 const SleepButton(),
                 const SpeedButton(),
                 const VolumeButton(),
+                // TODO: add bookmarks
               ],
             ),
             Text(

--- a/lib/features/player/ui/player_screen.dart
+++ b/lib/features/player/ui/player_screen.dart
@@ -120,6 +120,7 @@ class PlayerScreen extends ConsumerWidget {
                   child: const MiniProgressIndicator(),
                 ),
               ),
+            // TODO: add down arrow and more settings buttons
           ],
         );
       },

--- a/lib/features/settings/ui/downloads/downloads_settings_screen.dart
+++ b/lib/features/settings/ui/downloads/downloads_settings_screen.dart
@@ -42,6 +42,9 @@ class DownloadsSettingsScreen extends StatelessWidget {
           children: [
             // UnmeteredOnlyTile(), // TODO: add unmetered only tile
             // StorageTile(), // TODO: external download location
+            // for SAF check the following packages
+            // https://pub.dev/packages/saf_util
+            // https://pub.dev/packages/saf_stream
           ],
         ),
       ),

--- a/lib/features/settings/ui/downloads/downloads_settings_screen.dart
+++ b/lib/features/settings/ui/downloads/downloads_settings_screen.dart
@@ -2,10 +2,9 @@ import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 import 'package:storii/app/config/router.dart';
 import 'package:storii/app/init.dart';
-import 'package:storii/features/settings/ui/downloads/unmetered_only_tile.dart';
 
-class DownloadsTile extends StatelessWidget {
-  const DownloadsTile({super.key});
+class DownloadsSettingsTile extends StatelessWidget {
+  const DownloadsSettingsTile({super.key});
 
   @override
   Widget build(BuildContext context) {
@@ -39,7 +38,12 @@ class DownloadsSettingsScreen extends StatelessWidget {
         ),
       ),
       body: const SingleChildScrollView(
-        child: Column(children: [UnmeteredOnlyTile()]),
+        child: Column(
+          children: [
+            // UnmeteredOnlyTile(), // TODO: add unmetered only tile
+            // StorageTile(), // TODO: external download location
+          ],
+        ),
       ),
     );
   }

--- a/lib/features/settings/ui/settings_screen.dart
+++ b/lib/features/settings/ui/settings_screen.dart
@@ -35,6 +35,7 @@ class SettingsScreen extends StatelessWidget {
           AppearanceTile(),
           DateTimeFormatTile(),
           ConfigNavTile(),
+          // DownloadsSettingsTile(),
           PlayerSettingsTile(),
           LibrarySettingsTile(),
           HttpLogsTile(),

--- a/lib/features/settings/ui/storage_tile.dart
+++ b/lib/features/settings/ui/storage_tile.dart
@@ -1,0 +1,91 @@
+// import 'dart:io';
+
+// import 'package:file_picker/file_picker.dart';
+// import 'package:flutter/material.dart';
+// import 'package:flutter_riverpod/flutter_riverpod.dart';
+// import 'package:storii/app/init.dart';
+// import 'package:storii/app/logs/log_service.dart';
+// import 'package:storii/app/providers/settings_provider.dart';
+// import 'package:storii/shared/widgets/app_bottom_sheet.dart';
+
+// class StorageTile extends ConsumerWidget {
+//   const StorageTile({super.key});
+
+//   @override
+//   Widget build(BuildContext context, WidgetRef ref) {
+//     final path = ref.watch(externalDownloadPathProvider);
+
+//     return ListTile(
+//       trailing: const Icon(Icons.chevron_right),
+//       leading: const Icon(Icons.storage),
+//       title: Text(l10n.storage),
+//       subtitle: Text(path ?? l10n.internalStorage),
+//       onTap: () {
+//         AppBottomSheet.show(
+//           context,
+//           title: l10n.storage,
+//           body: Consumer(
+//             builder: (context, ref, _) {
+//               final externalPath = ref.watch(externalDownloadPathProvider);
+//               final isExternal = externalPath != null;
+//               final theme = Theme.of(context);
+
+//               return Column(
+//                 children: [
+//                   Padding(
+//                     padding: const .symmetric(horizontal: 24),
+//                     child: Text(
+//                       l10n.storageSubDirsNote,
+//                       style: theme.textTheme.labelLarge?.copyWith(
+//                         color: theme.colorScheme.onSurfaceVariant.withValues(
+//                           alpha: 0.7,
+//                         ),
+//                       ),
+//                     ),
+//                   ),
+//                   ListTile(
+//                     title: Text(l10n.downloadLocation),
+//                     subtitle: Text(externalPath ?? l10n.internalStorage),
+//                     trailing: TextButton(
+//                       onPressed: () async {
+//                         try {
+//                           final result = await FilePicker.getDirectoryPath();
+//                           if (result != null) {
+//                             final dir = Directory(result);
+//                             if (await dir.exists()) {
+//                               await ref
+//                                   .read(appSettingsProvider.notifier)
+//                                   .setExternalDownloadPath(result);
+//                             }
+//                           }
+//                         } catch (e) {
+//                           LogService.log(
+//                             'Error setting storage location',
+//                             level: .error,
+//                             originalError: e,
+//                             source: 'StorageTile',
+//                           );
+//                         }
+//                       },
+//                       child: Text(l10n.changeLocation),
+//                     ),
+//                   ),
+//                   const SizedBox(height: 16),
+//                   if (isExternal)
+//                     TextButton(
+//                       onPressed: () async {
+//                         await ref
+//                             .read(appSettingsProvider.notifier)
+//                             .setExternalDownloadPath(null);
+//                       },
+//                       child: Text(l10n.resetToInternal),
+//                     ),
+//                 ],
+//               );
+//             },
+//           ),
+//         );
+//       },
+//     );
+//   }
+// }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -412,5 +412,15 @@
   "changeLocation": "Change Location",
   "resetToInternal": "Reset to Internal",
   "downloadLocation": "Download Location",
-  "storageSubDirsNote": "Audiobooks and podcasts will be stored in separate subdirectories: \n- audiobooks/<itemId>/\n- podcasts/<podcastId>/\nThis ensures stable paths even if server metadata changes"
+  "storageSubDirsNote": "Audiobooks and podcasts will be stored in separate subdirectories: \n- audiobooks/<itemId>/\n- podcasts/<podcastId>/\nThis ensures stable paths even if server metadata changes",
+  "localSession": "Local Session: {time}",
+  "@localSession": {
+    "placeholders": {
+      "time": {
+        "type": "String"
+      }
+    }
+  },
+  "localSessionDeleteQ": "Delete local session?",
+  "localSessionDeleteBody": "This session progress is not synced with server yet"
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -406,5 +406,11 @@
         "type": "String"
       }
     }
-  }
+  },
+  "storage": "Storage",
+  "internalStorage": "Internal Storage",
+  "changeLocation": "Change Location",
+  "resetToInternal": "Reset to Internal",
+  "downloadLocation": "Download Location",
+  "storageSubDirsNote": "Audiobooks and podcasts will be stored in separate subdirectories: \n- audiobooks/<itemId>/\n- podcasts/<podcastId>/\nThis ensures stable paths even if server metadata changes"
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -422,5 +422,5 @@
     }
   },
   "localSessionDeleteQ": "Delete local session?",
-  "localSessionDeleteBody": "This session progress is not synced with server yet"
+  "localSessionDeleteBody": "This progress may not be fully synced yet. Check playback history for confirmation."
 }

--- a/lib/l10n/l10n.dart
+++ b/lib/l10n/l10n.dart
@@ -1953,6 +1953,24 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Audiobooks and podcasts will be stored in separate subdirectories: \n- audiobooks/<itemId>/\n- podcasts/<podcastId>/\nThis ensures stable paths even if server metadata changes'**
   String get storageSubDirsNote;
+
+  /// No description provided for @localSession.
+  ///
+  /// In en, this message translates to:
+  /// **'Local Session: {time}'**
+  String localSession(String time);
+
+  /// No description provided for @localSessionDeleteQ.
+  ///
+  /// In en, this message translates to:
+  /// **'Delete local session?'**
+  String get localSessionDeleteQ;
+
+  /// No description provided for @localSessionDeleteBody.
+  ///
+  /// In en, this message translates to:
+  /// **'This session progress is not synced with server yet'**
+  String get localSessionDeleteBody;
 }
 
 class _AppLocalizationsDelegate

--- a/lib/l10n/l10n.dart
+++ b/lib/l10n/l10n.dart
@@ -1917,6 +1917,42 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'{library} Library is empty!'**
   String libraryIsEmpty(String library);
+
+  /// No description provided for @storage.
+  ///
+  /// In en, this message translates to:
+  /// **'Storage'**
+  String get storage;
+
+  /// No description provided for @internalStorage.
+  ///
+  /// In en, this message translates to:
+  /// **'Internal Storage'**
+  String get internalStorage;
+
+  /// No description provided for @changeLocation.
+  ///
+  /// In en, this message translates to:
+  /// **'Change Location'**
+  String get changeLocation;
+
+  /// No description provided for @resetToInternal.
+  ///
+  /// In en, this message translates to:
+  /// **'Reset to Internal'**
+  String get resetToInternal;
+
+  /// No description provided for @downloadLocation.
+  ///
+  /// In en, this message translates to:
+  /// **'Download Location'**
+  String get downloadLocation;
+
+  /// No description provided for @storageSubDirsNote.
+  ///
+  /// In en, this message translates to:
+  /// **'Audiobooks and podcasts will be stored in separate subdirectories: \n- audiobooks/<itemId>/\n- podcasts/<podcastId>/\nThis ensures stable paths even if server metadata changes'**
+  String get storageSubDirsNote;
 }
 
 class _AppLocalizationsDelegate

--- a/lib/l10n/l10n.dart
+++ b/lib/l10n/l10n.dart
@@ -1969,7 +1969,7 @@ abstract class AppLocalizations {
   /// No description provided for @localSessionDeleteBody.
   ///
   /// In en, this message translates to:
-  /// **'This session progress is not synced with server yet'**
+  /// **'This progress may not be fully synced yet. Check playback history for confirmation.'**
   String get localSessionDeleteBody;
 }
 

--- a/lib/l10n/l10n_en.dart
+++ b/lib/l10n/l10n_en.dart
@@ -991,4 +991,16 @@ class AppLocalizationsEn extends AppLocalizations {
   @override
   String get storageSubDirsNote =>
       'Audiobooks and podcasts will be stored in separate subdirectories: \n- audiobooks/<itemId>/\n- podcasts/<podcastId>/\nThis ensures stable paths even if server metadata changes';
+
+  @override
+  String localSession(String time) {
+    return 'Local Session: $time';
+  }
+
+  @override
+  String get localSessionDeleteQ => 'Delete local session?';
+
+  @override
+  String get localSessionDeleteBody =>
+      'This session progress is not synced with server yet';
 }

--- a/lib/l10n/l10n_en.dart
+++ b/lib/l10n/l10n_en.dart
@@ -972,4 +972,23 @@ class AppLocalizationsEn extends AppLocalizations {
   String libraryIsEmpty(String library) {
     return '$library Library is empty!';
   }
+
+  @override
+  String get storage => 'Storage';
+
+  @override
+  String get internalStorage => 'Internal Storage';
+
+  @override
+  String get changeLocation => 'Change Location';
+
+  @override
+  String get resetToInternal => 'Reset to Internal';
+
+  @override
+  String get downloadLocation => 'Download Location';
+
+  @override
+  String get storageSubDirsNote =>
+      'Audiobooks and podcasts will be stored in separate subdirectories: \n- audiobooks/<itemId>/\n- podcasts/<podcastId>/\nThis ensures stable paths even if server metadata changes';
 }

--- a/lib/l10n/l10n_en.dart
+++ b/lib/l10n/l10n_en.dart
@@ -1002,5 +1002,5 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get localSessionDeleteBody =>
-      'This session progress is not synced with server yet';
+      'This progress may not be fully synced yet. Check playback history for confirmation.';
 }

--- a/lib/storage/local/session_store.dart
+++ b/lib/storage/local/session_store.dart
@@ -4,6 +4,8 @@ import 'dart:convert';
 import 'package:abs_api/abs_api.dart';
 import 'package:hive_ce/hive_ce.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
+import 'package:rxdart/rxdart.dart';
+import 'package:storii/shared/helpers/extensions.dart';
 import 'package:storii/storage/hive/boxes.dart';
 
 part 'session_store.g.dart';
@@ -24,8 +26,30 @@ class SessionStore extends _$SessionStore {
   }
 
   List<PlaybackSession> getAll() {
-    return _box.values
-        .map((json) => PlaybackSession.fromJson(jsonDecode(json)))
-        .toList();
+    return _box.values.map(_parseSession).toList();
   }
+
+  PlaybackSession? getSession(String itemId, [String? episodeId]) {
+    return _box.values
+        .map(_parseSession)
+        .firstWhereOrNull(
+          (s) => s.libraryItemId == itemId && s.episodeId == episodeId,
+        );
+  }
+
+  Stream<PlaybackSession?> watchSession(String itemId, [String? episodeId]) {
+    return _box
+        .watch()
+        .map((_) {
+          return _box.values
+              .map(_parseSession)
+              .firstWhereOrNull(
+                (s) => s.libraryItemId == itemId && s.episodeId == episodeId,
+              );
+        })
+        .startWith(getSession(itemId, episodeId));
+  }
+
+  PlaybackSession _parseSession(String json) =>
+      PlaybackSession.fromJson(jsonDecode(json));
 }

--- a/lib/storage/local/session_store.g.dart
+++ b/lib/storage/local/session_store.g.dart
@@ -40,7 +40,7 @@ final class SessionStoreProvider extends $NotifierProvider<SessionStore, void> {
   }
 }
 
-String _$sessionStoreHash() => r'13461ff1e3ea57339203b2dd2ed46b8e9569fc33';
+String _$sessionStoreHash() => r'54fbfd4aadafd3289ea55734ff1c4582059f3a54';
 
 abstract class _$SessionStore extends $Notifier<void> {
   void build();


### PR DESCRIPTION
## What does this PR do?

Bug fixes

### Changed

- Refactored download storage to use safe ID-based paths with automatic migration from old paths

### Fixed

- Enable podcast episode downloads
- Local session offline progress restoration
- Show downloads in home screen when offline
- Item detail provider cache fallback

Closes #58 #60 #55 

## Type of Change

- [x] Bug fix
- [x] Refactor

## Checklist

- [x] `dart format .` and `dart fix --apply` have been run
- [x] No lint errors or warnings (infos for TODOs are okay)
- [x] Code generation has been run if models or providers were changed (`dart run build_runner build`)
- [x] No `print` statements introduced
- [x] Tested against an Audiobookshelf server
