### PR TITLE
Feat/downloads

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,7 +33,6 @@ lib/l10n/gen/
 .pub-cache/
 .pub/
 /build/
-.local/
 
 # Symbolication related
 app.*.symbols

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - support android 17
 - OS notification controls: seek, skip forward/rewind, and skip chapter toggles
 - configurable skip-back after an external sound (e.g. notification) interrupts playback
+- persist media progress locally and order the downloads by most recently listened when offline
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - OS notification controls: seek, skip forward/rewind, and skip chapter toggles
 - configurable skip-back after an external sound (e.g. notification) interrupts playback
 - persist media progress locally and order the downloads by most recently listened when offline
-- downloads: sort by title, author, size, added, or last played with ascending/descending, and show completed downloads as a grid
+- downloads: search by title or author, sort by title, author, size, added, or last played with ascending/descending, and show completed downloads as a grid
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - OS notification controls: seek, skip forward/rewind, and skip chapter toggles
 - configurable skip-back after an external sound (e.g. notification) interrupts playback
 - persist media progress locally and order the downloads by most recently listened when offline
+- downloads: sort by title, author, size, added, or last played with ascending/descending, and show completed downloads as a grid
 
 ### Fixed
 

--- a/lib/app/providers/app_controller.dart
+++ b/lib/app/providers/app_controller.dart
@@ -1,4 +1,5 @@
 import 'package:riverpod_annotation/riverpod_annotation.dart';
+import 'package:storii/app/providers/media_progress_map_provider.dart';
 import 'package:storii/features/library/logic/active_library_provider.dart';
 import 'package:storii/features/player/logic/audio_providers.dart';
 import 'package:storii/features/player/logic/session_sync_watcher.dart';
@@ -13,4 +14,5 @@ void appController(Ref ref) {
   ref.watch(sessionSyncWatcherProvider);
   ref.watch(audioSettingsWatcherProvider);
   ref.watch(appStartThemeUpdateProvider);
+  ref.watch(mediaProgressSyncControllerProvider);
 }

--- a/lib/app/providers/app_controller.g.dart
+++ b/lib/app/providers/app_controller.g.dart
@@ -47,4 +47,4 @@ final class AppControllerProvider extends $FunctionalProvider<void, void, void>
   }
 }
 
-String _$appControllerHash() => r'508b69c77f87a0b1dc986b26045687f2f77c803e';
+String _$appControllerHash() => r'9e70fa4b4992f67cf58c4d2a636b7de18df27d17';

--- a/lib/app/providers/authenticated_user_provider.dart
+++ b/lib/app/providers/authenticated_user_provider.dart
@@ -6,6 +6,8 @@ import 'package:storii/app/providers/settings_provider.dart';
 import 'package:storii/features/auth/logic/users_provider.dart';
 import 'package:storii/shared/helpers/app_error.dart';
 import 'package:storii/shared/helpers/ref_extensions.dart';
+import 'package:storii/storage/local/server_settings_store.dart';
+import 'package:storii/storage/local/servers_store.dart';
 
 part 'authenticated_user_provider.g.dart';
 
@@ -23,6 +25,15 @@ Future<UserDomain> authenticatedUser(Ref ref) async {
       source: 'authenticatedUser',
       logMessage: 'Error authenticating user',
     );
+    final serverId = ref
+        .read(serversStoreProvider.notifier)
+        .get(user.serverUrl)
+        ?.id;
+    if (serverId != null) {
+      await ref
+          .read(serverSettingsStoreProvider.notifier)
+          .save(serverId, response.serverSettings);
+    }
     final refreshed = UserDomain(
       id: user.id,
       username: response.user.username,

--- a/lib/app/providers/authenticated_user_provider.g.dart
+++ b/lib/app/providers/authenticated_user_provider.g.dart
@@ -45,4 +45,4 @@ final class AuthenticatedUserProvider
   }
 }
 
-String _$authenticatedUserHash() => r'49efe67c4c7ce0439dda92ac3e6db846b10ca39e';
+String _$authenticatedUserHash() => r'ad484fd78d2f8ced6583aa1eb6d24a2885a1949c';

--- a/lib/app/providers/media_progress_map_provider.dart
+++ b/lib/app/providers/media_progress_map_provider.dart
@@ -3,50 +3,42 @@ import 'dart:async';
 import 'package:abs_api/abs_api.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 import 'package:storii/app/providers/api_providers.dart';
-import 'package:storii/app/providers/settings_provider.dart';
+import 'package:storii/app/providers/authenticated_user_provider.dart';
 import 'package:storii/app/providers/user_provider.dart';
 import 'package:storii/shared/helpers/abs_model_extensions.dart';
+import 'package:storii/storage/local/progress_store.dart';
 
 part 'media_progress_map_provider.g.dart';
 
-@riverpod
-class MediaProgressMap extends _$MediaProgressMap {
+@Riverpod(keepAlive: true)
+class MediaProgressSyncController extends _$MediaProgressSyncController {
   StreamSubscription? _progressSub;
 
+  ProgressStore get _store => ref.watch(progressStoreProvider.notifier);
+
   @override
-  Future<Map<String, MediaProgress>> build() async {
+  void build() async {
     ref.onDispose(() {
       _progressSub?.cancel();
     });
     await _progressSub?.cancel();
+
     try {
       final serverUser = await ref.watch(serverUserProvider.future);
-      final map = {
-        for (var p in serverUser.mediaProgress)
-          mediaItemIdKey(p.libraryItemId, p.episodeId): p,
-      };
+      _store.putAll(serverUser.mediaProgress);
 
-      final user = ref.watch(currentUserProvider);
-      if (user == null) {
-        return {};
-      }
-
-      final socket = await ref.watch(socketApiProvider(user).future);
-
+      final user = await ref.watch(authenticatedUserProvider.future);
+      final socket = await ref.read(socketApiProvider(user).future);
       _progressSub = socket.user.onProgressUpdate.listen((event) {
-        final current = state.value ?? {};
-        state = AsyncData({
-          ...current,
-          mediaItemIdKey(event.data.libraryItemId, event.data.episodeId):
-              event.data,
-        });
+        _store.put(event.data);
       });
-
-      return map;
-    } catch (_) {
-      return {};
-    }
+    } catch (_) {}
   }
+}
+
+@riverpod
+Future<Map<String, MediaProgress>> mediaProgressMap(Ref ref) {
+  return ref.watch(progressStoreProvider.future);
 }
 
 @riverpod
@@ -71,6 +63,6 @@ Future<MediaProgress?> mediaProgressFromMap(
   String libraryItemId, [
   String? episodeId,
 ]) async {
-  final key = mediaItemIdKey(libraryItemId, episodeId);
-  return ref.watch(mediaProgressMapProvider.selectAsync((map) => map[key]));
+  final map = await ref.watch(mediaProgressMapProvider.future);
+  return map[mediaItemIdKey(libraryItemId, episodeId)];
 }

--- a/lib/app/providers/media_progress_map_provider.g.dart
+++ b/lib/app/providers/media_progress_map_provider.g.dart
@@ -9,12 +9,73 @@ part of 'media_progress_map_provider.dart';
 // GENERATED CODE - DO NOT MODIFY BY HAND
 // ignore_for_file: type=lint, type=warning
 
-@ProviderFor(MediaProgressMap)
+@ProviderFor(MediaProgressSyncController)
+final mediaProgressSyncControllerProvider =
+    MediaProgressSyncControllerProvider._();
+
+final class MediaProgressSyncControllerProvider
+    extends $NotifierProvider<MediaProgressSyncController, void> {
+  MediaProgressSyncControllerProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'mediaProgressSyncControllerProvider',
+        isAutoDispose: false,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$mediaProgressSyncControllerHash();
+
+  @$internal
+  @override
+  MediaProgressSyncController create() => MediaProgressSyncController();
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(void value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<void>(value),
+    );
+  }
+}
+
+String _$mediaProgressSyncControllerHash() =>
+    r'43d3af1ea5fccdf931c3a422678d62edcdb12d7e';
+
+abstract class _$MediaProgressSyncController extends $Notifier<void> {
+  void build();
+  @$mustCallSuper
+  @override
+  WhenComplete runBuild() {
+    final ref = this.ref as $Ref<void, void>;
+    final element =
+        ref.element
+            as $ClassProviderElement<
+              AnyNotifier<void, void>,
+              void,
+              Object?,
+              Object?
+            >;
+    return element.handleCreate(ref, build);
+  }
+}
+
+@ProviderFor(mediaProgressMap)
 final mediaProgressMapProvider = MediaProgressMapProvider._();
 
 final class MediaProgressMapProvider
     extends
-        $AsyncNotifierProvider<MediaProgressMap, Map<String, MediaProgress>> {
+        $FunctionalProvider<
+          AsyncValue<Map<String, MediaProgress>>,
+          Map<String, MediaProgress>,
+          FutureOr<Map<String, MediaProgress>>
+        >
+    with
+        $FutureModifier<Map<String, MediaProgress>>,
+        $FutureProvider<Map<String, MediaProgress>> {
   MediaProgressMapProvider._()
     : super(
         from: null,
@@ -31,37 +92,17 @@ final class MediaProgressMapProvider
 
   @$internal
   @override
-  MediaProgressMap create() => MediaProgressMap();
-}
+  $FutureProviderElement<Map<String, MediaProgress>> $createElement(
+    $ProviderPointer pointer,
+  ) => $FutureProviderElement(pointer);
 
-String _$mediaProgressMapHash() => r'10c517b99276d3a1181dabdf2d5151c655434026';
-
-abstract class _$MediaProgressMap
-    extends $AsyncNotifier<Map<String, MediaProgress>> {
-  FutureOr<Map<String, MediaProgress>> build();
-  @$mustCallSuper
   @override
-  WhenComplete runBuild() {
-    final ref =
-        this.ref
-            as $Ref<
-              AsyncValue<Map<String, MediaProgress>>,
-              Map<String, MediaProgress>
-            >;
-    final element =
-        ref.element
-            as $ClassProviderElement<
-              AnyNotifier<
-                AsyncValue<Map<String, MediaProgress>>,
-                Map<String, MediaProgress>
-              >,
-              AsyncValue<Map<String, MediaProgress>>,
-              Object?,
-              Object?
-            >;
-    return element.handleCreate(ref, build);
+  FutureOr<Map<String, MediaProgress>> create(Ref ref) {
+    return mediaProgressMap(ref);
   }
 }
+
+String _$mediaProgressMapHash() => r'a4fbc446fc2c620fd069cb493f4258e01fa062bf';
 
 @ProviderFor(totalFinishedBooks)
 final totalFinishedBooksProvider = TotalFinishedBooksProvider._();
@@ -187,7 +228,7 @@ final class MediaProgressFromMapProvider
 }
 
 String _$mediaProgressFromMapHash() =>
-    r'd9750454d9d3153c2e33bf974143d410ae50251a';
+    r'7433542fbdf0624bd04dccb95b28abc9e5a17067';
 
 final class MediaProgressFromMapFamily extends $Family
     with

--- a/lib/app/providers/media_progress_map_provider.g.dart
+++ b/lib/app/providers/media_progress_map_provider.g.dart
@@ -43,7 +43,7 @@ final class MediaProgressSyncControllerProvider
 }
 
 String _$mediaProgressSyncControllerHash() =>
-    r'43d3af1ea5fccdf931c3a422678d62edcdb12d7e';
+    r'fcab590ce6f87035d6c3f9779f9c09b35db663a7';
 
 abstract class _$MediaProgressSyncController extends $Notifier<void> {
   void build();

--- a/lib/app/providers/user_provider.dart
+++ b/lib/app/providers/user_provider.dart
@@ -4,7 +4,10 @@ import 'package:abs_api/abs_api.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 import 'package:storii/app/providers/api_providers.dart';
 import 'package:storii/app/providers/authenticated_user_provider.dart';
+import 'package:storii/app/providers/settings_provider.dart';
 import 'package:storii/shared/helpers/extensions.dart';
+import 'package:storii/storage/local/server_settings_store.dart';
+import 'package:storii/storage/local/servers_store.dart';
 
 part 'user_provider.g.dart';
 
@@ -43,4 +46,16 @@ bool isUserAdmin(Ref ref) {
   final type = UserType.values.firstWhereOrNull((t) => t.name == user.userType);
   if (type == null) return false;
   return type.isAdmin;
+}
+
+@riverpod
+ServerSettings? currentServerSettings(Ref ref) {
+  final user = ref.watch(currentUserProvider);
+  if (user == null) return null;
+  final serverId = ref
+      .read(serversStoreProvider.notifier)
+      .get(user.serverUrl)
+      ?.id;
+  if (serverId == null) return null;
+  return ref.watch(serverSettingsStoreProvider).value?[serverId];
 }

--- a/lib/app/providers/user_provider.g.dart
+++ b/lib/app/providers/user_provider.g.dart
@@ -131,3 +131,46 @@ final class IsUserAdminProvider extends $FunctionalProvider<bool, bool, bool>
 }
 
 String _$isUserAdminHash() => r'c96de0368859e48e9ef7a9637eff8a66936f808c';
+
+@ProviderFor(currentServerSettings)
+final currentServerSettingsProvider = CurrentServerSettingsProvider._();
+
+final class CurrentServerSettingsProvider
+    extends
+        $FunctionalProvider<ServerSettings?, ServerSettings?, ServerSettings?>
+    with $Provider<ServerSettings?> {
+  CurrentServerSettingsProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'currentServerSettingsProvider',
+        isAutoDispose: true,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$currentServerSettingsHash();
+
+  @$internal
+  @override
+  $ProviderElement<ServerSettings?> $createElement($ProviderPointer pointer) =>
+      $ProviderElement(pointer);
+
+  @override
+  ServerSettings? create(Ref ref) {
+    return currentServerSettings(ref);
+  }
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(ServerSettings? value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<ServerSettings?>(value),
+    );
+  }
+}
+
+String _$currentServerSettingsHash() =>
+    r'2cec323c1be8fab5873bb9801d22d6748715ec3f';

--- a/lib/features/downloads/logic/downloads_provider.dart
+++ b/lib/features/downloads/logic/downloads_provider.dart
@@ -2,6 +2,7 @@ import 'package:abs_api/abs_api.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 import 'package:storii/app/init.dart';
 import 'package:storii/app/providers/media_progress_map_provider.dart';
+import 'package:storii/app/providers/user_provider.dart';
 import 'package:storii/features/downloads/models/download_item.dart';
 import 'package:storii/shared/helpers/abs_model_extensions.dart';
 import 'package:storii/storage/local/downloads_store.dart';
@@ -40,6 +41,14 @@ class DownloadSortAscending extends _$DownloadSortAscending {
   bool build() => true;
 
   void toggle() => state = !state;
+}
+
+@Riverpod(keepAlive: true)
+class DownloadSearchQuery extends _$DownloadSearchQuery {
+  @override
+  String build() => '';
+
+  void set(String value) => state = value;
 }
 
 @Riverpod(keepAlive: true)
@@ -93,9 +102,32 @@ final _zeroEpoch = DateTime.fromMillisecondsSinceEpoch(0);
 @riverpod
 List<DownloadItem> sortedCompletedDownloads(Ref ref) {
   final items = ref.watch(completedDownloadsProvider).value ?? [];
+  final query = ref.watch(downloadSearchQueryProvider).trim().toLowerCase();
+  final filtered = query.isEmpty ? items : _filterDownloads(ref, items, query);
   final sort = ref.watch(downloadSortTypeProvider);
   final ascending = ref.watch(downloadSortAscendingProvider);
-  return _sortDownloads(ref, items, sort, ascending);
+  return _sortDownloads(ref, filtered, sort, ascending);
+}
+
+@riverpod
+List<DownloadItem> sortedActiveDownloads(Ref ref) {
+  final items = ref.watch(activeDownloadsProvider).value ?? [];
+  final query = ref.watch(downloadSearchQueryProvider).trim().toLowerCase();
+  return query.isEmpty ? items : _filterDownloads(ref, items, query);
+}
+
+List<DownloadItem> _filterDownloads(
+  Ref ref,
+  List<DownloadItem> items,
+  String query,
+) {
+  final cache = ref.read(itemsCacheProvider.notifier);
+  return items.where((item) {
+    final title = cache.get(item.libraryItemId)?.title ?? item.title;
+    final author = cache.get(item.libraryItemId)?.authorName ?? item.author;
+    return title.toLowerCase().contains(query) ||
+        author.toLowerCase().contains(query);
+  }).toList();
 }
 
 List<DownloadItem> _sortDownloads(
@@ -105,6 +137,10 @@ List<DownloadItem> _sortDownloads(
   bool ascending,
 ) {
   final cache = ref.read(itemsCacheProvider.notifier);
+  final settings = ref.watch(currentServerSettingsProvider);
+  final prefixes = settings?.sortingIgnorePrefix == true
+      ? settings?.sortingPrefixes ?? <String>[]
+      : <String>[];
   final titles = <String, String>{};
   final authors = <String, String>{};
   final listenedAt = <String, DateTime>{};
@@ -120,8 +156,18 @@ List<DownloadItem> _sortDownloads(
   final dir = ascending ? 1 : -1;
   list.sort(
     (a, b) => switch (sort) {
-      .title => dir * title(a).compareTo(title(b)),
-      .author => dir * author(a).compareTo(author(b)),
+      .title =>
+        dir *
+            _sortKey(
+              title(a),
+              prefixes,
+            ).compareTo(_sortKey(title(b), prefixes)),
+      .author =>
+        dir *
+            _sortKey(
+              author(a),
+              prefixes,
+            ).compareTo(_sortKey(author(b), prefixes)),
       .size => dir * a.totalBytes.compareTo(b.totalBytes),
       .added =>
         dir * (a.startedAt ?? _zeroEpoch).compareTo(b.startedAt ?? _zeroEpoch),
@@ -129,6 +175,17 @@ List<DownloadItem> _sortDownloads(
     },
   );
   return list;
+}
+
+String _sortKey(String value, List<String> prefixes) {
+  String result = value;
+  for (final prefix in prefixes) {
+    result = result.replaceFirst(
+      RegExp('^${RegExp.escape(prefix)}\\s+', caseSensitive: false),
+      '',
+    );
+  }
+  return result.toLowerCase();
 }
 
 DateTime _lastListenedTime(Ref ref, DownloadItem item) {

--- a/lib/features/downloads/logic/downloads_provider.dart
+++ b/lib/features/downloads/logic/downloads_provider.dart
@@ -1,25 +1,51 @@
+import 'package:abs_api/abs_api.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
+import 'package:storii/app/init.dart';
+import 'package:storii/app/providers/media_progress_map_provider.dart';
 import 'package:storii/features/downloads/models/download_item.dart';
 import 'package:storii/shared/helpers/abs_model_extensions.dart';
 import 'package:storii/storage/local/downloads_store.dart';
+import 'package:storii/storage/local/items_cache.dart';
+import 'package:storii/storage/local/session_store.dart';
 
 part 'downloads_provider.g.dart';
 
+enum DownloadSortType {
+  title,
+  author,
+  size,
+  added,
+  lastListened;
+
+  String get label => switch (this) {
+    .title => l10n.title,
+    .author => l10n.author,
+    .size => l10n.size,
+    .added => l10n.added,
+    .lastListened => l10n.lastPlayed,
+  };
+}
+
 @Riverpod(keepAlive: true)
-class DownloadsNotifier extends _$DownloadsNotifier {
+class DownloadSortTypeNotifier extends _$DownloadSortTypeNotifier {
   @override
-  Stream<Map<String, DownloadItem>> build() async* {
-    final items = await ref.watch(downloadsStoreProvider.future);
-    yield items;
-  }
+  DownloadSortType build() => .added;
 
-  Future<void> save(DownloadItem item) async {
-    await ref.read(downloadsStoreProvider.notifier).save(item);
-  }
+  void set(DownloadSortType value) => state = value;
+}
 
-  Future<void> remove(String id) async {
-    await ref.read(downloadsStoreProvider.notifier).remove(id);
-  }
+@Riverpod(keepAlive: true)
+class DownloadSortAscending extends _$DownloadSortAscending {
+  @override
+  bool build() => true;
+
+  void toggle() => state = !state;
+}
+
+@Riverpod(keepAlive: true)
+Stream<Map<String, DownloadItem>> downloads(Ref ref) async* {
+  final items = await ref.watch(downloadsStoreProvider.future);
+  yield items;
 }
 
 @riverpod
@@ -60,4 +86,77 @@ Future<int?> downloadQueuePosition(
   )).toList();
   final index = queuedItems.indexWhere((item) => item.key == key);
   return index != -1 ? index + 1 : null;
+}
+
+final _zeroEpoch = DateTime.fromMillisecondsSinceEpoch(0);
+
+@riverpod
+List<DownloadItem> sortedCompletedDownloads(Ref ref) {
+  final items = ref.watch(completedDownloadsProvider).value ?? [];
+  final sort = ref.watch(downloadSortTypeProvider);
+  final ascending = ref.watch(downloadSortAscendingProvider);
+  return _sortDownloads(ref, items, sort, ascending);
+}
+
+List<DownloadItem> _sortDownloads(
+  Ref ref,
+  List<DownloadItem> items,
+  DownloadSortType sort,
+  bool ascending,
+) {
+  final cache = ref.read(itemsCacheProvider.notifier);
+  final titles = <String, String>{};
+  final authors = <String, String>{};
+  final listenedAt = <String, DateTime>{};
+
+  String title(DownloadItem item) => titles[item.libraryItemId] ??=
+      cache.get(item.libraryItemId)?.title ?? item.title;
+  String author(DownloadItem item) => authors[item.libraryItemId] ??=
+      cache.get(item.libraryItemId)?.authorName ?? item.author;
+  DateTime lastListened(DownloadItem item) =>
+      listenedAt[item.key] ??= _lastListenedTime(ref, item);
+
+  final list = List<DownloadItem>.from(items);
+  final dir = ascending ? 1 : -1;
+  list.sort(
+    (a, b) => switch (sort) {
+      .title => dir * title(a).compareTo(title(b)),
+      .author => dir * author(a).compareTo(author(b)),
+      .size => dir * a.totalBytes.compareTo(b.totalBytes),
+      .added =>
+        dir * (a.startedAt ?? _zeroEpoch).compareTo(b.startedAt ?? _zeroEpoch),
+      .lastListened => dir * lastListened(a).compareTo(lastListened(b)),
+    },
+  );
+  return list;
+}
+
+DateTime _lastListenedTime(Ref ref, DownloadItem item) {
+  final session = ref
+      .watch(sessionStoreProvider.notifier)
+      .getSession(item.libraryItemId, item.episodeId);
+  if (session?.updatedAt != null) return session!.updatedAt;
+  final progress = ref
+      .watch(mediaProgressFromMapProvider(item.libraryItemId, item.episodeId))
+      .value;
+  if (progress?.lastUpdate != null) return progress!.lastUpdate!;
+
+  return _zeroEpoch;
+}
+
+@riverpod
+List<LibraryItem> downloadedItems(Ref ref) {
+  final items = ref.watch(sortedCompletedDownloadsProvider);
+  final cache = ref.watch(itemsCacheProvider.notifier);
+
+  final libraryItems = <LibraryItem>[];
+  final seen = <String>{};
+  for (final item in items) {
+    if (!seen.add(item.libraryItemId)) continue;
+    final libraryItem = cache.get(item.libraryItemId);
+    if (libraryItem == null) continue;
+    libraryItems.add(libraryItem);
+  }
+
+  return libraryItems;
 }

--- a/lib/features/downloads/logic/downloads_provider.g.dart
+++ b/lib/features/downloads/logic/downloads_provider.g.dart
@@ -115,6 +115,59 @@ abstract class _$DownloadSortAscending extends $Notifier<bool> {
   }
 }
 
+@ProviderFor(DownloadSearchQuery)
+final downloadSearchQueryProvider = DownloadSearchQueryProvider._();
+
+final class DownloadSearchQueryProvider
+    extends $NotifierProvider<DownloadSearchQuery, String> {
+  DownloadSearchQueryProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'downloadSearchQueryProvider',
+        isAutoDispose: false,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$downloadSearchQueryHash();
+
+  @$internal
+  @override
+  DownloadSearchQuery create() => DownloadSearchQuery();
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(String value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<String>(value),
+    );
+  }
+}
+
+String _$downloadSearchQueryHash() =>
+    r'f7264f5c22c141df1c8aa17ce40487528ffcc85e';
+
+abstract class _$DownloadSearchQuery extends $Notifier<String> {
+  String build();
+  @$mustCallSuper
+  @override
+  WhenComplete runBuild() {
+    final ref = this.ref as $Ref<String, String>;
+    final element =
+        ref.element
+            as $ClassProviderElement<
+              AnyNotifier<String, String>,
+              String,
+              Object?,
+              Object?
+            >;
+    return element.handleCreate(ref, build);
+  }
+}
+
 @ProviderFor(downloads)
 final downloadsProvider = DownloadsProvider._();
 
@@ -437,7 +490,55 @@ final class SortedCompletedDownloadsProvider
 }
 
 String _$sortedCompletedDownloadsHash() =>
-    r'2a391cd3faf87a3bc77a0bed99e69e351870a252';
+    r'348d4a5900f7a560d91e5cf97eae1bb35bda4fed';
+
+@ProviderFor(sortedActiveDownloads)
+final sortedActiveDownloadsProvider = SortedActiveDownloadsProvider._();
+
+final class SortedActiveDownloadsProvider
+    extends
+        $FunctionalProvider<
+          List<DownloadItem>,
+          List<DownloadItem>,
+          List<DownloadItem>
+        >
+    with $Provider<List<DownloadItem>> {
+  SortedActiveDownloadsProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'sortedActiveDownloadsProvider',
+        isAutoDispose: true,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$sortedActiveDownloadsHash();
+
+  @$internal
+  @override
+  $ProviderElement<List<DownloadItem>> $createElement(
+    $ProviderPointer pointer,
+  ) => $ProviderElement(pointer);
+
+  @override
+  List<DownloadItem> create(Ref ref) {
+    return sortedActiveDownloads(ref);
+  }
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(List<DownloadItem> value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<List<DownloadItem>>(value),
+    );
+  }
+}
+
+String _$sortedActiveDownloadsHash() =>
+    r'8a40ac1209ce6a5ccfb91810a811a8d7555d368e';
 
 @ProviderFor(downloadedItems)
 final downloadedItemsProvider = DownloadedItemsProvider._();

--- a/lib/features/downloads/logic/downloads_provider.g.dart
+++ b/lib/features/downloads/logic/downloads_provider.g.dart
@@ -9,13 +9,126 @@ part of 'downloads_provider.dart';
 // GENERATED CODE - DO NOT MODIFY BY HAND
 // ignore_for_file: type=lint, type=warning
 
-@ProviderFor(DownloadsNotifier)
-final downloadsProvider = DownloadsNotifierProvider._();
+@ProviderFor(DownloadSortTypeNotifier)
+final downloadSortTypeProvider = DownloadSortTypeNotifierProvider._();
 
-final class DownloadsNotifierProvider
+final class DownloadSortTypeNotifierProvider
+    extends $NotifierProvider<DownloadSortTypeNotifier, DownloadSortType> {
+  DownloadSortTypeNotifierProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'downloadSortTypeProvider',
+        isAutoDispose: false,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$downloadSortTypeNotifierHash();
+
+  @$internal
+  @override
+  DownloadSortTypeNotifier create() => DownloadSortTypeNotifier();
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(DownloadSortType value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<DownloadSortType>(value),
+    );
+  }
+}
+
+String _$downloadSortTypeNotifierHash() =>
+    r'575726cfdfdf345f7d5afc01e4d86c856981c2cb';
+
+abstract class _$DownloadSortTypeNotifier extends $Notifier<DownloadSortType> {
+  DownloadSortType build();
+  @$mustCallSuper
+  @override
+  WhenComplete runBuild() {
+    final ref = this.ref as $Ref<DownloadSortType, DownloadSortType>;
+    final element =
+        ref.element
+            as $ClassProviderElement<
+              AnyNotifier<DownloadSortType, DownloadSortType>,
+              DownloadSortType,
+              Object?,
+              Object?
+            >;
+    return element.handleCreate(ref, build);
+  }
+}
+
+@ProviderFor(DownloadSortAscending)
+final downloadSortAscendingProvider = DownloadSortAscendingProvider._();
+
+final class DownloadSortAscendingProvider
+    extends $NotifierProvider<DownloadSortAscending, bool> {
+  DownloadSortAscendingProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'downloadSortAscendingProvider',
+        isAutoDispose: false,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$downloadSortAscendingHash();
+
+  @$internal
+  @override
+  DownloadSortAscending create() => DownloadSortAscending();
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(bool value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<bool>(value),
+    );
+  }
+}
+
+String _$downloadSortAscendingHash() =>
+    r'8dd255862e907b40a1469e11164b49c4c60b4c80';
+
+abstract class _$DownloadSortAscending extends $Notifier<bool> {
+  bool build();
+  @$mustCallSuper
+  @override
+  WhenComplete runBuild() {
+    final ref = this.ref as $Ref<bool, bool>;
+    final element =
+        ref.element
+            as $ClassProviderElement<
+              AnyNotifier<bool, bool>,
+              bool,
+              Object?,
+              Object?
+            >;
+    return element.handleCreate(ref, build);
+  }
+}
+
+@ProviderFor(downloads)
+final downloadsProvider = DownloadsProvider._();
+
+final class DownloadsProvider
     extends
-        $StreamNotifierProvider<DownloadsNotifier, Map<String, DownloadItem>> {
-  DownloadsNotifierProvider._()
+        $FunctionalProvider<
+          AsyncValue<Map<String, DownloadItem>>,
+          Map<String, DownloadItem>,
+          Stream<Map<String, DownloadItem>>
+        >
+    with
+        $FutureModifier<Map<String, DownloadItem>>,
+        $StreamProvider<Map<String, DownloadItem>> {
+  DownloadsProvider._()
     : super(
         from: null,
         argument: null,
@@ -27,41 +140,21 @@ final class DownloadsNotifierProvider
       );
 
   @override
-  String debugGetCreateSourceHash() => _$downloadsNotifierHash();
+  String debugGetCreateSourceHash() => _$downloadsHash();
 
   @$internal
   @override
-  DownloadsNotifier create() => DownloadsNotifier();
-}
+  $StreamProviderElement<Map<String, DownloadItem>> $createElement(
+    $ProviderPointer pointer,
+  ) => $StreamProviderElement(pointer);
 
-String _$downloadsNotifierHash() => r'595b9f28b8aa0015f428b2f88e4858976855b46d';
-
-abstract class _$DownloadsNotifier
-    extends $StreamNotifier<Map<String, DownloadItem>> {
-  Stream<Map<String, DownloadItem>> build();
-  @$mustCallSuper
   @override
-  WhenComplete runBuild() {
-    final ref =
-        this.ref
-            as $Ref<
-              AsyncValue<Map<String, DownloadItem>>,
-              Map<String, DownloadItem>
-            >;
-    final element =
-        ref.element
-            as $ClassProviderElement<
-              AnyNotifier<
-                AsyncValue<Map<String, DownloadItem>>,
-                Map<String, DownloadItem>
-              >,
-              AsyncValue<Map<String, DownloadItem>>,
-              Object?,
-              Object?
-            >;
-    return element.handleCreate(ref, build);
+  Stream<Map<String, DownloadItem>> create(Ref ref) {
+    return downloads(ref);
   }
 }
+
+String _$downloadsHash() => r'62cd18e91b41c5412085b1e894abeb9ba4e4d97f';
 
 @ProviderFor(downloadItem)
 final downloadItemProvider = DownloadItemFamily._();
@@ -297,3 +390,98 @@ final class DownloadQueuePositionFamily extends $Family
   @override
   String toString() => r'downloadQueuePositionProvider';
 }
+
+@ProviderFor(sortedCompletedDownloads)
+final sortedCompletedDownloadsProvider = SortedCompletedDownloadsProvider._();
+
+final class SortedCompletedDownloadsProvider
+    extends
+        $FunctionalProvider<
+          List<DownloadItem>,
+          List<DownloadItem>,
+          List<DownloadItem>
+        >
+    with $Provider<List<DownloadItem>> {
+  SortedCompletedDownloadsProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'sortedCompletedDownloadsProvider',
+        isAutoDispose: true,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$sortedCompletedDownloadsHash();
+
+  @$internal
+  @override
+  $ProviderElement<List<DownloadItem>> $createElement(
+    $ProviderPointer pointer,
+  ) => $ProviderElement(pointer);
+
+  @override
+  List<DownloadItem> create(Ref ref) {
+    return sortedCompletedDownloads(ref);
+  }
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(List<DownloadItem> value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<List<DownloadItem>>(value),
+    );
+  }
+}
+
+String _$sortedCompletedDownloadsHash() =>
+    r'2a391cd3faf87a3bc77a0bed99e69e351870a252';
+
+@ProviderFor(downloadedItems)
+final downloadedItemsProvider = DownloadedItemsProvider._();
+
+final class DownloadedItemsProvider
+    extends
+        $FunctionalProvider<
+          List<LibraryItem>,
+          List<LibraryItem>,
+          List<LibraryItem>
+        >
+    with $Provider<List<LibraryItem>> {
+  DownloadedItemsProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'downloadedItemsProvider',
+        isAutoDispose: true,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$downloadedItemsHash();
+
+  @$internal
+  @override
+  $ProviderElement<List<LibraryItem>> $createElement(
+    $ProviderPointer pointer,
+  ) => $ProviderElement(pointer);
+
+  @override
+  List<LibraryItem> create(Ref ref) {
+    return downloadedItems(ref);
+  }
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(List<LibraryItem> value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<List<LibraryItem>>(value),
+    );
+  }
+}
+
+String _$downloadedItemsHash() => r'57f65289cdefded306de0c797ace17822209a19c';

--- a/lib/features/downloads/ui/download_sort_sheet.dart
+++ b/lib/features/downloads/ui/download_sort_sheet.dart
@@ -1,0 +1,35 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:material_ui/material_ui.dart';
+import 'package:storii/features/downloads/logic/downloads_provider.dart';
+
+class DownloadSortSheet extends ConsumerWidget {
+  const DownloadSortSheet({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final sortType = ref.watch(downloadSortTypeProvider);
+    final ascending = ref.watch(downloadSortAscendingProvider);
+
+    return SingleChildScrollView(
+      child: Column(
+        children: [
+          ...DownloadSortType.values.map((type) {
+            final isSelected = sortType == type;
+            return ListTile(
+              title: Text(type.label),
+              selected: isSelected,
+              trailing: isSelected
+                  ? Icon(ascending ? Icons.arrow_upward : Icons.arrow_downward)
+                  : null,
+              onTap: () => isSelected
+                  ? ref.read(downloadSortAscendingProvider.notifier).toggle()
+                  : ref.read(downloadSortTypeProvider.notifier).set(type),
+              contentPadding: const .symmetric(horizontal: 24, vertical: 0),
+            );
+          }),
+          const SizedBox(height: 48),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/features/downloads/ui/download_tile.dart
+++ b/lib/features/downloads/ui/download_tile.dart
@@ -1,0 +1,102 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+import 'package:material_ui/material_ui.dart';
+import 'package:storii/app/config/router.dart';
+import 'package:storii/features/downloads/models/download_item.dart';
+import 'package:storii/features/downloads/ui/download_widgets.dart';
+import 'package:storii/features/library/ui/image_widget.dart';
+
+class DownloadTile extends StatefulWidget {
+  const DownloadTile({super.key, required this.item});
+
+  final DownloadItem item;
+
+  @override
+  State<DownloadTile> createState() => _DownloadTileState();
+}
+
+class _DownloadTileState extends State<DownloadTile> {
+  bool isExpanded = true;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    return Column(
+      mainAxisSize: .min,
+      children: [
+        ListTile(
+          contentPadding: const .fromLTRB(16, 8, 16, 4),
+          onTap: widget.item.isComplete
+              ? () => context.push(
+                  AppRoute.itemDetail.path,
+                  extra: {
+                    'id': widget.item.libraryItemId,
+                    'isDownloaded': true,
+                  },
+                )
+              : null,
+          leading: AspectRatio(
+            aspectRatio: 1,
+            child: ClipRRect(
+              borderRadius: .circular(8),
+              child: ImageWidget(id: widget.item.libraryItemId, type: .item),
+            ),
+          ),
+          title: Column(
+            crossAxisAlignment: .start,
+            children: [
+              Text(
+                widget.item.title,
+                maxLines: 2,
+                overflow: .ellipsis,
+                style: theme.textTheme.titleSmall,
+              ),
+              if (widget.item.author.isNotEmpty)
+                Text(
+                  widget.item.author,
+                  maxLines: 1,
+                  overflow: .ellipsis,
+                  style: theme.textTheme.bodySmall?.copyWith(
+                    color: theme.colorScheme.onSurfaceVariant,
+                  ),
+                ),
+              const SizedBox(height: 4),
+              DownloadStatusRow(item: widget.item),
+            ],
+          ),
+          subtitle: Row(
+            mainAxisAlignment: .spaceEvenly,
+            children: [
+              Consumer(
+                builder: (context, ref, _) {
+                  return IconButton(
+                    icon: const Icon(Icons.delete_outline),
+                    onPressed: () => showDownloadsDeleteDialog(
+                      context,
+                      item: widget.item,
+                      ref: ref,
+                    ),
+                  );
+                },
+              ),
+              DownloadTileTrailingActions(item: widget.item),
+              IconButton(
+                icon: const Icon(Icons.more_horiz),
+                onPressed: () => setState(() {
+                  isExpanded = !isExpanded;
+                }),
+              ),
+            ],
+          ),
+        ),
+        AnimatedContainer(
+          duration: const Duration(milliseconds: 300),
+          child: isExpanded
+              ? DownloadTrackProgress(item: widget.item)
+              : const SizedBox.shrink(),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/features/downloads/ui/downloads_screen.dart
+++ b/lib/features/downloads/ui/downloads_screen.dart
@@ -1,16 +1,12 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:go_router/go_router.dart';
 import 'package:material_ui/material_ui.dart';
-import 'package:storii/app/config/router.dart';
 import 'package:storii/app/init.dart';
-import 'package:storii/app/providers/settings_provider.dart';
 import 'package:storii/features/downloads/logic/downloads_provider.dart';
-import 'package:storii/features/downloads/models/download_item.dart';
-import 'package:storii/features/downloads/ui/download_widgets.dart';
-import 'package:storii/features/library/ui/image_widget.dart';
-import 'package:storii/shared/helpers/helpers.dart';
+import 'package:storii/features/downloads/ui/download_sort_sheet.dart';
+import 'package:storii/features/downloads/ui/download_tile.dart';
+import 'package:storii/features/library/ui/items_grid_view.dart';
+import 'package:storii/shared/widgets/app_bottom_sheet.dart';
 import 'package:storii/shared/widgets/empty_state.dart';
-import 'package:storii/shared/widgets/marquee_text.dart';
 
 enum DownloadsScreenTab { active, completed }
 
@@ -53,9 +49,12 @@ class _DownloadsScreenState extends ConsumerState<DownloadsScreen>
 
   @override
   Widget build(BuildContext context) {
-    final activeDownloads = ref.watch(activeDownloadsProvider).value ?? [];
-    final completedDownloads =
-        ref.watch(completedDownloadsProvider).value ?? [];
+    final activeCount = ref.watch(
+      activeDownloadsProvider.select((list) => list.value?.length ?? 0),
+    );
+    final completedCount = ref.watch(
+      completedDownloadsProvider.select((list) => list.value?.length ?? 0),
+    );
 
     return Scaffold(
       appBar: AppBar(
@@ -67,200 +66,62 @@ class _DownloadsScreenState extends ConsumerState<DownloadsScreen>
           controller: _tabController,
           tabs: [
             Tab(
-              text: activeDownloads.isEmpty
+              text: activeCount == 0
                   ? l10n.active
-                  : '${l10n.active} (${activeDownloads.length})',
+                  : '${l10n.active} ($activeCount)',
             ),
             Tab(
-              text: completedDownloads.isEmpty
+              text: completedCount == 0
                   ? l10n.completed
-                  : '${l10n.completed} (${completedDownloads.length})',
+                  : '${l10n.completed} ($completedCount)',
             ),
           ],
         ),
+        actions: [
+          IconButton(
+            icon: const Icon(Icons.sort),
+            tooltip: l10n.sort,
+            onPressed: () => AppBottomSheet.show(
+              context,
+              title: l10n.sort,
+              body: const DownloadSortSheet(),
+            ),
+          ),
+        ],
       ),
       body: TabBarView(
         controller: _tabController,
-        children: [
-          if (activeDownloads.isEmpty)
-            const EmptyState()
-          else
-            ListView.builder(
-              padding: const .only(bottom: 16, top: 4),
-              itemCount: activeDownloads.length,
-              itemBuilder: (context, index) {
-                final item = activeDownloads.elementAt(index);
-                return DownloadTile(item: item);
-              },
-            ),
-          if (completedDownloads.isEmpty)
-            const EmptyState()
-          else
-            ListView.builder(
-              padding: const .only(bottom: 16, top: 4),
-              itemCount: completedDownloads.length,
-              itemBuilder: (context, index) {
-                final item = completedDownloads.elementAt(index);
-                return CompletedItemTile(item);
-              },
-            ),
-        ],
+        children: const [ActiveDownloadsTab(), CompletedDownloadsTab()],
       ),
     );
   }
 }
 
-class CompletedItemTile extends ConsumerWidget {
-  const CompletedItemTile(this.item, {super.key});
-  final DownloadItem item;
+class ActiveDownloadsTab extends ConsumerWidget {
+  const ActiveDownloadsTab({super.key});
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final theme = Theme.of(context);
-    final useBinary = ref.watch(useBinaryBytesProvider);
+    final items = ref.watch(activeDownloadsProvider).value ?? [];
 
-    return ListTile(
-      onTap: () {
-        context.push(
-          AppRoute.itemDetail.path,
-          extra: {'id': item.libraryItemId},
-        );
-      },
-      contentPadding: const .fromLTRB(16, 8, 0, 8),
-      leading: AspectRatio(
-        aspectRatio: 1,
-        child: ClipRRect(
-          borderRadius: .circular(4),
-          child: ImageWidget(id: item.libraryItemId, type: .item),
-        ),
-      ),
-      minVerticalPadding: 0,
-      horizontalTitleGap: 8,
-      titleAlignment: .center,
-      title: Column(
-        mainAxisSize: .min,
-        crossAxisAlignment: .start,
-        children: [
-          MarqueeText(item.title, style: theme.textTheme.titleSmall),
-          const SizedBox(height: 2),
-          MarqueeText(
-            item.author,
-            style: theme.textTheme.bodyMedium?.copyWith(
-              color: theme.colorScheme.onSurfaceVariant,
-            ),
-          ),
-          const SizedBox(height: 2),
-        ],
-      ),
-      subtitle: Text(
-        formatBytes(item.receivedBytes, useBinary: useBinary),
-        style: theme.textTheme.labelSmall,
-      ),
-      trailing: Consumer(
-        builder: (context, ref, _) {
-          return IconButton(
-            onPressed: () {
-              showDownloadsDeleteDialog(context, item: item, ref: ref);
-            },
-            icon: const Icon(Icons.delete_outline),
-          );
-        },
-      ),
+    if (items.isEmpty) {
+      return const EmptyState();
+    }
+
+    return ListView.builder(
+      padding: const .only(bottom: 16, top: 4),
+      itemCount: items.length,
+      itemBuilder: (context, index) => DownloadTile(item: items[index]),
     );
   }
 }
 
-class DownloadTile extends StatefulWidget {
-  const DownloadTile({super.key, required this.item});
-
-  final DownloadItem item;
+class CompletedDownloadsTab extends ConsumerWidget {
+  const CompletedDownloadsTab({super.key});
 
   @override
-  State<DownloadTile> createState() => _DownloadTileState();
-}
-
-class _DownloadTileState extends State<DownloadTile> {
-  bool isExpanded = true;
-
-  @override
-  Widget build(BuildContext context) {
-    final theme = Theme.of(context);
-
-    return Column(
-      mainAxisSize: .min,
-      children: [
-        ListTile(
-          contentPadding: const .fromLTRB(16, 8, 16, 4),
-          onTap: widget.item.isComplete
-              ? () => context.push(
-                  AppRoute.itemDetail.path,
-                  extra: {
-                    'id': widget.item.libraryItemId,
-                    'isDownloaded': true,
-                  },
-                )
-              : null,
-          leading: AspectRatio(
-            aspectRatio: 1,
-            child: ClipRRect(
-              borderRadius: .circular(8),
-              child: ImageWidget(id: widget.item.libraryItemId, type: .item),
-            ),
-          ),
-          title: Column(
-            crossAxisAlignment: .start,
-            children: [
-              Text(
-                widget.item.title,
-                maxLines: 2,
-                overflow: .ellipsis,
-                style: theme.textTheme.titleSmall,
-              ),
-              if (widget.item.author.isNotEmpty)
-                Text(
-                  widget.item.author,
-                  maxLines: 1,
-                  overflow: .ellipsis,
-                  style: theme.textTheme.bodySmall?.copyWith(
-                    color: theme.colorScheme.onSurfaceVariant,
-                  ),
-                ),
-              const SizedBox(height: 4),
-              DownloadStatusRow(item: widget.item),
-            ],
-          ),
-          subtitle: Row(
-            mainAxisAlignment: .spaceEvenly,
-            children: [
-              Consumer(
-                builder: (context, ref, _) {
-                  return IconButton(
-                    icon: const Icon(Icons.delete_outline),
-                    onPressed: () => showDownloadsDeleteDialog(
-                      context,
-                      item: widget.item,
-                      ref: ref,
-                    ),
-                  );
-                },
-              ),
-              DownloadTileTrailingActions(item: widget.item),
-              IconButton(
-                icon: const Icon(Icons.more_horiz),
-                onPressed: () => setState(() {
-                  isExpanded = !isExpanded;
-                }),
-              ),
-            ],
-          ),
-        ),
-        AnimatedContainer(
-          duration: const Duration(milliseconds: 300),
-          child: isExpanded
-              ? DownloadTrackProgress(item: widget.item)
-              : const SizedBox.shrink(),
-        ),
-      ],
-    );
+  Widget build(BuildContext context, WidgetRef ref) {
+    final items = ref.watch(downloadedItemsProvider);
+    return ItemsGridView(items);
   }
 }

--- a/lib/features/downloads/ui/downloads_screen.dart
+++ b/lib/features/downloads/ui/downloads_screen.dart
@@ -22,6 +22,8 @@ class DownloadsScreen extends ConsumerStatefulWidget {
 class _DownloadsScreenState extends ConsumerState<DownloadsScreen>
     with SingleTickerProviderStateMixin {
   late TabController _tabController;
+  final _searchController = TextEditingController();
+  bool _searching = false;
 
   @override
   void initState() {
@@ -43,12 +45,24 @@ class _DownloadsScreenState extends ConsumerState<DownloadsScreen>
 
   @override
   void dispose() {
+    _searchController.dispose();
     _tabController.dispose();
     super.dispose();
   }
 
+  void _toggleSearch() {
+    setState(() {
+      _searching = !_searching;
+      if (!_searching) {
+        _searchController.clear();
+        ref.read(downloadSearchQueryProvider.notifier).set('');
+      }
+    });
+  }
+
   @override
   Widget build(BuildContext context) {
+    final theme = Theme.of(context);
     final activeCount = ref.watch(
       activeDownloadsProvider.select((list) => list.value?.length ?? 0),
     );
@@ -58,10 +72,21 @@ class _DownloadsScreenState extends ConsumerState<DownloadsScreen>
 
     return Scaffold(
       appBar: AppBar(
-        title: Text(
-          l10n.downloads,
-          style: Theme.of(context).textTheme.titleLarge,
-        ),
+        title: _searching
+            ? Material(
+                type: .transparency,
+                child: TextField(
+                  autofocus: true,
+                  controller: _searchController,
+                  onChanged: ref.read(downloadSearchQueryProvider.notifier).set,
+                  decoration: InputDecoration(
+                    hint: Text(l10n.search, style: theme.textTheme.titleSmall),
+                    border: .none,
+                  ),
+                ),
+              )
+            : Text(l10n.downloads, style: theme.textTheme.titleLarge),
+        titleSpacing: _searching ? 0 : theme.appBarTheme.titleSpacing,
         bottom: TabBar(
           controller: _tabController,
           tabs: [
@@ -78,6 +103,11 @@ class _DownloadsScreenState extends ConsumerState<DownloadsScreen>
           ],
         ),
         actions: [
+          IconButton(
+            icon: Icon(_searching ? Icons.close : Icons.search),
+            tooltip: l10n.search,
+            onPressed: _toggleSearch,
+          ),
           IconButton(
             icon: const Icon(Icons.sort),
             tooltip: l10n.sort,
@@ -102,7 +132,7 @@ class ActiveDownloadsTab extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final items = ref.watch(activeDownloadsProvider).value ?? [];
+    final items = ref.watch(sortedActiveDownloadsProvider);
 
     if (items.isEmpty) {
       return const EmptyState();

--- a/lib/features/home/logic/shelves_provider.dart
+++ b/lib/features/home/logic/shelves_provider.dart
@@ -89,20 +89,24 @@ Future<List<Shelf>> rawShelves(Ref ref) async {
   if (!isConnected) {
     final downloads = await ref.read(downloadsProvider.future);
     final cache = ref.read(itemsCacheProvider.notifier);
-    final audiobooks = <LibraryItem>[];
-    final podcasts = <LibraryItem>[];
+
+    final dAudiobooks = <LibraryItem>[];
+    final dPodcasts = <LibraryItem>[];
 
     for (final d in downloads.values.where((d) => d.isComplete)) {
       final item = cache.get(d.libraryItemId);
       if (item != null) {
         switch (item.mediaType) {
           case .book:
-            audiobooks.add(item);
+            dAudiobooks.add(item);
           case .podcast:
-            podcasts.add(item);
+            dPodcasts.add(item);
         }
       }
     }
+
+    final audiobooks = dAudiobooks.take(10).toList();
+    final podcasts = dPodcasts.take(10).toList();
 
     final downloadShelves = [
       if (audiobooks.isNotEmpty)

--- a/lib/features/home/logic/shelves_provider.dart
+++ b/lib/features/home/logic/shelves_provider.dart
@@ -8,6 +8,7 @@ import 'package:storii/features/downloads/logic/downloads_provider.dart';
 import 'package:storii/features/library/logic/active_library_provider.dart';
 import 'package:storii/shared/helpers/ref_extensions.dart';
 import 'package:storii/storage/local/items_cache.dart';
+import 'package:storii/storage/local/session_store.dart';
 
 part 'shelves_provider.g.dart';
 
@@ -45,6 +46,41 @@ Future<List<Shelf>> shelves(Ref ref) async {
         },
       )
       .toList();
+}
+
+@riverpod
+Future<List<Shelf>> sortedShelves(Ref ref) async {
+  final shelves = await ref.watch(shelvesProvider.future);
+  final sessions = ref.watch(sessionStoreProvider).value ?? [];
+
+  final latestSessionByItem = <String, PlaybackSession>{};
+  for (final session in sessions) {
+    final current = latestSessionByItem[session.libraryItemId];
+    if (current == null || session.updatedAt.isAfter(current.updatedAt)) {
+      latestSessionByItem[session.libraryItemId] = session;
+    }
+  }
+
+  DateTime lastListenedAt(LibraryItem item) {
+    final session = latestSessionByItem[item.id];
+    if (session != null) return session.updatedAt;
+    return item.userMediaProgress?.lastUpdate ?? DateTime(0);
+  }
+
+  return shelves.map((shelf) {
+    return switch (shelf) {
+      LibraryItemsShelf() =>
+        shelf.id == 'offline_downloads'
+            ? shelf.copyWith(
+                entities: [...shelf.entities]
+                  ..sort(
+                    (a, b) => lastListenedAt(b).compareTo(lastListenedAt(a)),
+                  ),
+              )
+            : shelf,
+      _ => shelf,
+    };
+  }).toList();
 }
 
 @riverpod

--- a/lib/features/home/logic/shelves_provider.g.dart
+++ b/lib/features/home/logic/shelves_provider.g.dart
@@ -48,6 +48,45 @@ final class ShelvesProvider
 
 String _$shelvesHash() => r'345fdd366f9cefc848d6b0ff19a4198de267b466';
 
+@ProviderFor(sortedShelves)
+final sortedShelvesProvider = SortedShelvesProvider._();
+
+final class SortedShelvesProvider
+    extends
+        $FunctionalProvider<
+          AsyncValue<List<Shelf>>,
+          List<Shelf>,
+          FutureOr<List<Shelf>>
+        >
+    with $FutureModifier<List<Shelf>>, $FutureProvider<List<Shelf>> {
+  SortedShelvesProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'sortedShelvesProvider',
+        isAutoDispose: true,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$sortedShelvesHash();
+
+  @$internal
+  @override
+  $FutureProviderElement<List<Shelf>> $createElement(
+    $ProviderPointer pointer,
+  ) => $FutureProviderElement(pointer);
+
+  @override
+  FutureOr<List<Shelf>> create(Ref ref) {
+    return sortedShelves(ref);
+  }
+}
+
+String _$sortedShelvesHash() => r'cfc11ad73226a33e6f9b2241f5f36fa75c69b469';
+
 @ProviderFor(rawShelves)
 final rawShelvesProvider = RawShelvesProvider._();
 

--- a/lib/features/home/logic/shelves_provider.g.dart
+++ b/lib/features/home/logic/shelves_provider.g.dart
@@ -124,4 +124,4 @@ final class RawShelvesProvider
   }
 }
 
-String _$rawShelvesHash() => r'1466cd44d457ff45f8dc84c511f50cd34765027a';
+String _$rawShelvesHash() => r'9a858951d20f786387f19fed942b9eee9baf97a7';

--- a/lib/features/home/ui/home_screen.dart
+++ b/lib/features/home/ui/home_screen.dart
@@ -20,7 +20,7 @@ class HomeScreen extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final shelvesAsync = ref.watch(shelvesProvider);
+    final shelvesAsync = ref.watch(sortedShelvesProvider);
     final theme = Theme.of(context);
 
     return Scaffold(
@@ -29,7 +29,7 @@ class HomeScreen extends ConsumerWidget {
         onRefresh: () async {
           ref.invalidate(rawShelvesProvider);
           ref.invalidate(serverUserProvider);
-          await ref.read(shelvesProvider.future);
+          await ref.read(sortedShelvesProvider.future);
         },
         child: shelvesAsync.when(
           skipLoadingOnReload: true,

--- a/lib/features/library/logic/grid_height_provider.dart
+++ b/lib/features/library/logic/grid_height_provider.dart
@@ -13,7 +13,7 @@ double gridHeight(Ref ref) {
     .comfortable => () {
       final scaler = ref.watch(textScalerProvider);
       final titleSlot = scaler.scale(32.0);
-      final authorSlot = scaler.scale(16.0);
+      final authorSlot = scaler.scale(20.0);
       const padding = 16.0;
       final metadataHeight = titleSlot + padding + authorSlot;
 

--- a/lib/features/library/logic/grid_height_provider.g.dart
+++ b/lib/features/library/logic/grid_height_provider.g.dart
@@ -48,7 +48,7 @@ final class GridHeightProvider
   }
 }
 
-String _$gridHeightHash() => r'13e0aae56639e2794b3375847a4c2b38d9694887';
+String _$gridHeightHash() => r'42a934f400f872939be304b26ed02840589e52d3';
 
 @ProviderFor(authorsGridHeight)
 final authorsGridHeightProvider = AuthorsGridHeightProvider._();

--- a/lib/features/library/ui/more_options_widget.dart
+++ b/lib/features/library/ui/more_options_widget.dart
@@ -5,6 +5,8 @@ import 'package:storii/app/init.dart';
 import 'package:storii/app/providers/media_progress_map_provider.dart';
 import 'package:storii/app/providers/user_provider.dart';
 import 'package:storii/features/admin/logic/item_actions_provider.dart';
+import 'package:storii/features/downloads/logic/download_queue.dart';
+import 'package:storii/features/downloads/logic/downloads_provider.dart';
 import 'package:storii/features/item/logic/user_progress_actions.dart';
 import 'package:storii/shared/helpers/extensions.dart';
 import 'package:storii/shared/widgets/app_bottom_sheet.dart';
@@ -160,6 +162,21 @@ class _MoreOptionsWidgetState extends ConsumerState<_MoreOptionsWidget> {
           l10n.seriesRemovedFromContinueListening,
           l10n.removeSeriesFromContinueListeningFailed,
         ),
+      ));
+    }
+
+    final downloaded = ref.watch(
+      downloadItemProvider(widget.itemId, widget.episodeId),
+    );
+    if (downloaded != null) {
+      options.add((
+        title: l10n.removeDownloadQ,
+        icon: Icons.delete_outline,
+        onTap: () async {
+          await ref
+              .read(downloadQueueProvider.notifier)
+              .delete(widget.itemId, widget.episodeId);
+        },
       ));
     }
 

--- a/lib/features/player/logic/audio_handler.dart
+++ b/lib/features/player/logic/audio_handler.dart
@@ -149,7 +149,9 @@ class AppAudioHandler extends BaseAudioHandler with QueueHandler, SeekHandler {
     final resolvedMediaItem = queue.value.elementAtOrNull(
       resolved.chapterIndex,
     );
-    mediaItem.add(resolvedMediaItem);
+    if (mediaItem.value != resolvedMediaItem) {
+      mediaItem.add(resolvedMediaItem);
+    }
 
     final resolvedBuffered =
         resolver.resolveChapterFromTrack(state.index, state.bufferedPosition) ??

--- a/lib/storage/hive/boxes.dart
+++ b/lib/storage/hive/boxes.dart
@@ -15,6 +15,7 @@ const usersBoxName = 'users_box';
 const serversBoxName = 'servers_box';
 const itemsBoxName = 'items_box';
 const localSessionsBoxName = 'local_sessions_box';
+const mediaProgressBoxName = 'media_progress_box';
 const playbackHistoryBoxName = 'playback_history_box';
 const downloadsBoxName = 'downloads_box';
 const speedsBoxName = 'speeds_box';
@@ -31,6 +32,7 @@ late final Box<String> localSessionsBox;
 late final Box<List<dynamic>> playbackHistoryBox;
 late final Box<String> downloadsBox;
 late final Box<double> speedsBox;
+late final Box<String> mediaProgressBox;
 
 Future<void> setupHive() async {
   await Hive.initFlutter();
@@ -59,6 +61,8 @@ Future<void> setupHive() async {
     Hive.openBox<double>(speedsBoxName),
   ).wait;
 
+  final mediaProgress = await Hive.openBox<String>(mediaProgressBoxName);
+
   appSettingsBox = appSettings;
   userSettingsBox = userSettings;
   usersBox = users;
@@ -68,6 +72,7 @@ Future<void> setupHive() async {
   playbackHistoryBox = playbackHistory;
   downloadsBox = downloads;
   speedsBox = speeds;
+  mediaProgressBox = mediaProgress;
 
   // dio cache
   final dir = await getApplicationDocumentsDirectory();

--- a/lib/storage/hive/boxes.dart
+++ b/lib/storage/hive/boxes.dart
@@ -19,6 +19,7 @@ const mediaProgressBoxName = 'media_progress_box';
 const playbackHistoryBoxName = 'playback_history_box';
 const downloadsBoxName = 'downloads_box';
 const speedsBoxName = 'speeds_box';
+const serverSettingsBoxName = 'server_settings_box';
 
 const networkCacheDir = 'dio_cache';
 late final HiveCacheStore networkCacheStore;
@@ -33,6 +34,7 @@ late final Box<List<dynamic>> playbackHistoryBox;
 late final Box<String> downloadsBox;
 late final Box<double> speedsBox;
 late final Box<String> mediaProgressBox;
+late final Box<String> serverSettingsBox;
 
 Future<void> setupHive() async {
   await Hive.initFlutter();
@@ -61,7 +63,10 @@ Future<void> setupHive() async {
     Hive.openBox<double>(speedsBoxName),
   ).wait;
 
-  final mediaProgress = await Hive.openBox<String>(mediaProgressBoxName);
+  final (mediaProgress, serverSettings) = await (
+    Hive.openBox<String>(mediaProgressBoxName),
+    Hive.openBox<String>(serverSettingsBoxName),
+  ).wait;
 
   appSettingsBox = appSettings;
   userSettingsBox = userSettings;
@@ -73,6 +78,7 @@ Future<void> setupHive() async {
   downloadsBox = downloads;
   speedsBox = speeds;
   mediaProgressBox = mediaProgress;
+  serverSettingsBox = serverSettings;
 
   // dio cache
   final dir = await getApplicationDocumentsDirectory();

--- a/lib/storage/local/progress_store.dart
+++ b/lib/storage/local/progress_store.dart
@@ -26,7 +26,9 @@ class ProgressStore extends _$ProgressStore {
       values
           .map(_itemFromValue)
           .whereType<MediaProgress>()
-          .map((p) => MapEntry(mediaItemIdKey(p.libraryItemId, p.episodeId), p)),
+          .map(
+            (p) => MapEntry(mediaItemIdKey(p.libraryItemId, p.episodeId), p),
+          ),
     );
   }
 

--- a/lib/storage/local/progress_store.dart
+++ b/lib/storage/local/progress_store.dart
@@ -1,0 +1,70 @@
+import 'dart:convert';
+import 'dart:developer';
+
+import 'package:abs_api/abs_api.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+import 'package:rxdart/rxdart.dart';
+import 'package:storii/shared/helpers/abs_model_extensions.dart';
+import 'package:storii/storage/hive/boxes.dart';
+
+part 'progress_store.g.dart';
+
+@Riverpod(keepAlive: true)
+class ProgressStore extends _$ProgressStore {
+  MediaProgress? _itemFromValue(String? value) {
+    if (value == null) return null;
+    try {
+      return MediaProgress.fromJson(jsonDecode(value));
+    } catch (e) {
+      log('Failed to decode media progress: $e');
+      return null;
+    }
+  }
+
+  Map<String, MediaProgress> _decode(Iterable<String> values) {
+    return Map.fromEntries(
+      values
+          .map(_itemFromValue)
+          .whereType<MediaProgress>()
+          .map((p) => MapEntry(mediaItemIdKey(p.libraryItemId, p.episodeId), p)),
+    );
+  }
+
+  @override
+  Stream<Map<String, MediaProgress>> build() {
+    final items = _decode(mediaProgressBox.values);
+    return mediaProgressBox
+        .watch()
+        .map((event) {
+          if (event.deleted) {
+            items.remove(event.key);
+          } else {
+            final item = _itemFromValue(event.value as String?);
+            if (item != null) {
+              items[mediaItemIdKey(item.libraryItemId, item.episodeId)] = item;
+            } else {
+              items.remove(event.key);
+            }
+          }
+          return Map<String, MediaProgress>.from(items);
+        })
+        .startWith(Map<String, MediaProgress>.from(items));
+  }
+
+  void put(MediaProgress progress) {
+    try {
+      mediaProgressBox.put(
+        mediaItemIdKey(progress.libraryItemId, progress.episodeId),
+        jsonEncode(progress),
+      );
+    } catch (e) {
+      log('Failed to save media progress: $e');
+    }
+  }
+
+  void putAll(List<MediaProgress> list) {
+    for (final progress in list) {
+      put(progress);
+    }
+  }
+}

--- a/lib/storage/local/progress_store.g.dart
+++ b/lib/storage/local/progress_store.g.dart
@@ -1,0 +1,63 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'progress_store.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, type=warning
+
+@ProviderFor(ProgressStore)
+final progressStoreProvider = ProgressStoreProvider._();
+
+final class ProgressStoreProvider
+    extends $StreamNotifierProvider<ProgressStore, Map<String, MediaProgress>> {
+  ProgressStoreProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'progressStoreProvider',
+        isAutoDispose: false,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$progressStoreHash();
+
+  @$internal
+  @override
+  ProgressStore create() => ProgressStore();
+}
+
+String _$progressStoreHash() => r'cac76f991844e9eec3ff13b75987e68417883b84';
+
+abstract class _$ProgressStore
+    extends $StreamNotifier<Map<String, MediaProgress>> {
+  Stream<Map<String, MediaProgress>> build();
+  @$mustCallSuper
+  @override
+  WhenComplete runBuild() {
+    final ref =
+        this.ref
+            as $Ref<
+              AsyncValue<Map<String, MediaProgress>>,
+              Map<String, MediaProgress>
+            >;
+    final element =
+        ref.element
+            as $ClassProviderElement<
+              AnyNotifier<
+                AsyncValue<Map<String, MediaProgress>>,
+                Map<String, MediaProgress>
+              >,
+              AsyncValue<Map<String, MediaProgress>>,
+              Object?,
+              Object?
+            >;
+    return element.handleCreate(ref, build);
+  }
+}

--- a/lib/storage/local/server_settings_store.dart
+++ b/lib/storage/local/server_settings_store.dart
@@ -1,0 +1,35 @@
+import 'dart:convert';
+
+import 'package:abs_api/abs_api.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+import 'package:rxdart/rxdart.dart';
+import 'package:storii/storage/hive/boxes.dart';
+
+part 'server_settings_store.g.dart';
+
+@Riverpod(keepAlive: true)
+class ServerSettingsStore extends _$ServerSettingsStore {
+  @override
+  Stream<Map<String, ServerSettings>> build() =>
+      serverSettingsBox.watch().map((_) => _readAll()).startWith(_readAll());
+
+  Map<String, ServerSettings> _readAll() {
+    return {
+      for (final entry in serverSettingsBox.toMap().entries)
+        entry.key as String: ServerSettings.fromJson(
+          jsonDecode(entry.value) as Map<String, dynamic>,
+        ),
+    };
+  }
+
+  Future<void> save(String serverId, ServerSettings settings) =>
+      serverSettingsBox.put(serverId, jsonEncode(settings.toJson()));
+
+  Future<void> remove(String serverId) => serverSettingsBox.delete(serverId);
+
+  ServerSettings? get(String serverId) {
+    final raw = serverSettingsBox.get(serverId);
+    if (raw == null) return null;
+    return ServerSettings.fromJson(jsonDecode(raw) as Map<String, dynamic>);
+  }
+}

--- a/lib/storage/local/server_settings_store.g.dart
+++ b/lib/storage/local/server_settings_store.g.dart
@@ -1,0 +1,68 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'server_settings_store.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, type=warning
+
+@ProviderFor(ServerSettingsStore)
+final serverSettingsStoreProvider = ServerSettingsStoreProvider._();
+
+final class ServerSettingsStoreProvider
+    extends
+        $StreamNotifierProvider<
+          ServerSettingsStore,
+          Map<String, ServerSettings>
+        > {
+  ServerSettingsStoreProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'serverSettingsStoreProvider',
+        isAutoDispose: false,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$serverSettingsStoreHash();
+
+  @$internal
+  @override
+  ServerSettingsStore create() => ServerSettingsStore();
+}
+
+String _$serverSettingsStoreHash() =>
+    r'91a9b0ca5f90ea198a45486cc3d32169108963ea';
+
+abstract class _$ServerSettingsStore
+    extends $StreamNotifier<Map<String, ServerSettings>> {
+  Stream<Map<String, ServerSettings>> build();
+  @$mustCallSuper
+  @override
+  WhenComplete runBuild() {
+    final ref =
+        this.ref
+            as $Ref<
+              AsyncValue<Map<String, ServerSettings>>,
+              Map<String, ServerSettings>
+            >;
+    final element =
+        ref.element
+            as $ClassProviderElement<
+              AnyNotifier<
+                AsyncValue<Map<String, ServerSettings>>,
+                Map<String, ServerSettings>
+              >,
+              AsyncValue<Map<String, ServerSettings>>,
+              Object?,
+              Object?
+            >;
+    return element.handleCreate(ref, build);
+  }
+}

--- a/lib/storage/local/session_store.dart
+++ b/lib/storage/local/session_store.dart
@@ -12,7 +12,13 @@ part 'session_store.g.dart';
 @Riverpod(keepAlive: true)
 class SessionStore extends _$SessionStore {
   @override
-  void build() {}
+  Stream<List<PlaybackSession>> build() {
+    final items = localSessionsBox.values.map(_parseSession).toList();
+    return localSessionsBox
+        .watch()
+        .map((_) => localSessionsBox.values.map(_parseSession).toList())
+        .startWith(items);
+  }
 
   Future<void> save(PlaybackSession session) async {
     await localSessionsBox.put(session.id, jsonEncode(session));

--- a/lib/storage/local/session_store.g.dart
+++ b/lib/storage/local/session_store.g.dart
@@ -12,7 +12,8 @@ part of 'session_store.dart';
 @ProviderFor(SessionStore)
 final sessionStoreProvider = SessionStoreProvider._();
 
-final class SessionStoreProvider extends $NotifierProvider<SessionStore, void> {
+final class SessionStoreProvider
+    extends $StreamNotifierProvider<SessionStore, List<PlaybackSession>> {
   SessionStoreProvider._()
     : super(
         from: null,
@@ -30,29 +31,26 @@ final class SessionStoreProvider extends $NotifierProvider<SessionStore, void> {
   @$internal
   @override
   SessionStore create() => SessionStore();
-
-  /// {@macro riverpod.override_with_value}
-  Override overrideWithValue(void value) {
-    return $ProviderOverride(
-      origin: this,
-      providerOverride: $SyncValueProvider<void>(value),
-    );
-  }
 }
 
-String _$sessionStoreHash() => r'32dd5e7685333502b05c9fba8550cf36911df8ac';
+String _$sessionStoreHash() => r'f7167ac455ec07dafa5bde4e179776a2e1719512';
 
-abstract class _$SessionStore extends $Notifier<void> {
-  void build();
+abstract class _$SessionStore extends $StreamNotifier<List<PlaybackSession>> {
+  Stream<List<PlaybackSession>> build();
   @$mustCallSuper
   @override
   WhenComplete runBuild() {
-    final ref = this.ref as $Ref<void, void>;
+    final ref =
+        this.ref
+            as $Ref<AsyncValue<List<PlaybackSession>>, List<PlaybackSession>>;
     final element =
         ref.element
             as $ClassProviderElement<
-              AnyNotifier<void, void>,
-              void,
+              AnyNotifier<
+                AsyncValue<List<PlaybackSession>>,
+                List<PlaybackSession>
+              >,
+              AsyncValue<List<PlaybackSession>>,
               Object?,
               Object?
             >;


### PR DESCRIPTION
## What does this PR do?

### Added
- persist media progress locally and order the downloads by most recently listened when offline
- downloads: search by title or author, sort by title, author, size, added, or last played with ascending/descending, and show completed downloads as a grid

Closes #107 #108

## Type of Change

- [x] Bug fix
- [x] New feature

## Checklist

- [x] `dart format .` - 0 changed
- [x] `dart fix --apply` - Nothing to fix
- [x] `flutter analyze` - No issues found
- [x] `dart run build_runner build` - No outputs
- [x] Tested against an Audiobookshelf server
